### PR TITLE
Bookmarking changes

### DIFF
--- a/tap_shopify/__init__.py
+++ b/tap_shopify/__init__.py
@@ -118,8 +118,11 @@ def sync():
                                 bookmark_properties=stream["replication_key"])
             Context.counts[stream["tap_stream_id"]] = 0
 
+    # If there is a currently syncing stream bookmark, shuffle the
+    # stream order so it gets sync'd first
     currently_sync_stream_name = Context.state.get('bookmarks', {}).get('currently_sync_stream')
-    shuffle_streams(currently_sync_stream_name)
+    if currently_sync_stream_name:
+        shuffle_streams(currently_sync_stream_name)
 
     # Loop over streams in catalog
     for catalog_entry in Context.catalog['streams']:

--- a/tap_shopify/streams/base.py
+++ b/tap_shopify/streams/base.py
@@ -107,9 +107,11 @@ class Stream():
                 for obj in objects:
                     yield obj
 
-                    # You know you're at the end when the current page has
-                    # less than the request size limits you set.
+                # You know you're at the end when the current page has
+                # less than the request size limits you set.
                 if len(objects) < RESULTS_PER_PAGE:
+                    # Save the updated_at_max as our bookmark as we've synced all rows up in our
+                    # window and can move forward
                     self.update_bookmark(utils.strftime(updated_at_max))
                     break
 

--- a/tap_shopify/streams/collects.py
+++ b/tap_shopify/streams/collects.py
@@ -1,5 +1,4 @@
 import shopify
-import singer
 from singer import utils
 from tap_shopify.streams.base import (Stream,
                                       RESULTS_PER_PAGE)

--- a/tap_shopify/streams/collects.py
+++ b/tap_shopify/streams/collects.py
@@ -1,5 +1,6 @@
-import singer
 import shopify
+import singer
+from singer import utils
 from tap_shopify.streams.base import (Stream,
                                       RESULTS_PER_PAGE)
 from tap_shopify.context import Context
@@ -8,29 +9,29 @@ from tap_shopify.context import Context
 class Collects(Stream):
     name = 'collects'
     replication_object = shopify.Collect
-    replication_key = 'id'
+    replication_key = 'updated_at'
 
     def get_objects(self):
         page = 1
-        start_id = singer.get_bookmark(Context.state,
-                                       self.name,
-                                       self.replication_key)
-
+        bookmark = self.get_bookmark()
+        max_bookmark = utils.strftime(utils.now())
         while True:
             query_params = {
                 "page": page,
                 "limit": RESULTS_PER_PAGE,
             }
-            if start_id:
-                query_params["since_id"] = start_id
 
             objects = self.call_api(query_params)
 
             for obj in objects:
-                yield obj
-                self.update_bookmark(obj)
+                # Syncing Collects is a full sync every time but emitting records that have
+                # an updated_date greater than the bookmark
+                if utils.strptime_with_tz(obj.updated_at) > bookmark:
+                    yield obj
 
             if len(objects) < RESULTS_PER_PAGE:
+                # Update the bookmark at the end of the last page
+                self.update_bookmark(max_bookmark)
                 break
             page += 1
 


### PR DESCRIPTION
The `order` query param we were using was undocumented, and we saw a few examples of records coming back out of order.

We decided to use the `updated_at_max` query param as the bookmark, and write it after we finish writing all records returned between `updated_at_min` and `updated_at_max`.  