### PR TITLE
Support private Shopify apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,7 @@ This tap:
 
 1. Install
 
-   ```sh
-   pip install tap-shopify
-   ```
+    pip install tap-shopify
 
 2. Create the config file
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ This tap:
 
 1. Install
 
-    pip install tap-shopify
+   ```sh
+   pip install tap-shopify
+   ```
 
 2. Create the config file
 
@@ -44,6 +46,17 @@ This tap:
    The `api_key` is the API key for your Shopify shop generated via an OAuth flow.
 
    The `shop` is your Shopify shop which will be the value `test_shop` in the string `https://test_shop.myshopify.com`
+   
+   (Optional) If you have a **private** Shopify app, add the app password using `password` in `config.json`
+
+   ```json
+    {
+        "start_date": "2010-01-01",
+        "api_key": "<Shopify API Key>",
+        "password": "<Shopify Private App Password>",
+        "shop": "test_shop"
+    }
+    ```
 
 4. Run the Tap in Discovery Mode
 

--- a/tap_shopify/__init__.py
+++ b/tap_shopify/__init__.py
@@ -20,8 +20,17 @@ LOGGER = singer.get_logger()
 def initialize_shopify_client():
     api_key = Context.config['api_key']
     shop = Context.config['shop']
-    session = shopify.Session(shop, api_key)
-    shopify.ShopifyResource.activate_session(session)
+
+    if 'password' in Context.config:
+        password = Context.config['password']
+        shop_url = 'https://{}:{}@{}.myshopify.com/admin'.format(
+            api_key,
+            password,
+            shop)
+        shopify.ShopifyResource.set_site(shop_url)
+    else:
+        session = shopify.Session(shop, api_key)
+        shopify.ShopifyResource.activate_session(session)
 
 def get_abs_path(path):
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), path)


### PR DESCRIPTION
This allows users to pass the private app `password`, supporting private Shopify apps.

Functional Testing
- Replicating `orders` using a private Shopify app's credentials.