### PR TITLE
Reset the since_id to 1 after finishing a window of data

### DIFF
--- a/tap_shopify/streams/base.py
+++ b/tap_shopify/streams/base.py
@@ -167,6 +167,7 @@ class Stream():
                     # restart at 1.
                     Context.state.get(self.name, {}).pop('since_id', None)
                     self.update_bookmark(utils.strftime(updated_at_max))
+                    since_id = 1
                     break
 
                 if objects[-1].id != max([o.id for o in objects]):


### PR DESCRIPTION
When the `since_id` bookmarking was added, it was never resetting the value within the pagination loop. This has the effect of only replicating a sort of "upper triangle" of data based on the `ID` of each record.

This PR resets the local `since_id` variable to 1 after each date window to ensure that all records are replicated appropriately.