### PR TITLE
check to make sure record has updated_at

### DIFF
--- a/tap_shopify/streams/collects.py
+++ b/tap_shopify/streams/collects.py
@@ -1,10 +1,12 @@
 import shopify
+import singer
 from singer import utils
 from tap_shopify.streams.base import (Stream,
                                       RESULTS_PER_PAGE,
                                       OutOfOrderIdsError)
 from tap_shopify.context import Context
 
+LOGGER = singer.get_logger()
 
 class Collects(Stream):
     name = 'collects'
@@ -26,7 +28,9 @@ class Collects(Stream):
             for obj in objects:
                 # Syncing Collects is a full sync every time but emitting records that have
                 # an updated_date greater than the bookmark
-                if utils.strptime_with_tz(obj.updated_at) > bookmark:
+                if not obj.updated_at and obj.id:
+                    LOGGER.info('Collect with id: %d does not have an updated_at, syncing it!', obj.id)
+                if not obj.updated_at or utils.strptime_with_tz(obj.updated_at) > bookmark:
                     if obj.id < since_id:
                         raise OutOfOrderIdsError("obj.id < since_id: {} < {}".format(
                             obj.id, since_id))

--- a/tap_shopify/streams/collects.py
+++ b/tap_shopify/streams/collects.py
@@ -26,10 +26,12 @@ class Collects(Stream):
             objects = self.call_api(query_params)
 
             for obj in objects:
-                # Syncing Collects is a full sync every time but emitting records that have
-                # an updated_date greater than the bookmark
+                # Syncing Collects is a full sync every time but emitting
+                # records that have an updated_date greater than the
+                # bookmark
                 if not obj.updated_at and obj.id:
-                    LOGGER.info('Collect with id: %d does not have an updated_at, syncing it!', obj.id)
+                    LOGGER.info('Collect with id: %d does not have an updated_at, syncing it!',
+                                obj.id)
                 if not obj.updated_at or utils.strptime_with_tz(obj.updated_at) > bookmark:
                     if obj.id < since_id:
                         raise OutOfOrderIdsError("obj.id < since_id: {} < {}".format(


### PR DESCRIPTION
tap-shopify was running into errors when `collects` came through without an `updated_at`.

This adds code to check for an `updated_at`, and if it doesn't exist, the tap won't attempt to compare it to the bookmark -- it will just sync that `collect`.

This means that `collects` without an `updated_at` will be sync'd on every run.  