### PR TITLE
fix since_id bookmark popping

### DIFF
--- a/tap_shopify/streams/base.py
+++ b/tap_shopify/streams/base.py
@@ -166,7 +166,6 @@ class Stream():
                     # restart at 1.
                     Context.state.get('bookmarks', {}).get(self.name, {}).pop('since_id', None)
                     self.update_bookmark(utils.strftime(updated_at_max))
-
                     break
 
                 if objects[-1].id != max([o.id for o in objects]):

--- a/tap_shopify/streams/base.py
+++ b/tap_shopify/streams/base.py
@@ -164,8 +164,9 @@ class Stream():
                     # Save the updated_at_max as our bookmark as we've synced all rows up in our
                     # window and can move forward. Also remove the since_id because we want to
                     # restart at 1.
-                    Context.state.get(self.name, {}).pop('since_id', None)
+                    Context.state.get('bookmarks', {}).get(self.name, {}).pop('since_id', None)
                     self.update_bookmark(utils.strftime(updated_at_max))
+
                     break
 
                 if objects[-1].id != max([o.id for o in objects]):


### PR DESCRIPTION
The tap was incorrectly removing the `since_id` bookmark when the end of a date range had been sync'd.  This led to dropped records when the tap resumed since `since_id` should have been reset to 1.