### PR TITLE
canonicalize transaction__receipt__token

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,8 +8,9 @@ jobs:
       - run:
           name: 'Setup virtual env'
           command: |
-            virtualenv -p python3 /usr/local/share/virtualenvs/tap-shopify
+            python3 -mvenv /usr/local/share/virtualenvs/tap-shopify
             source /usr/local/share/virtualenvs/tap-shopify/bin/activate
+            pip install -U 'pip<19.2' setuptools
             pip install .[dev]
       - run:
           name: 'pylint'


### PR DESCRIPTION
We have observed transactions with receipt objects that contain both `token` and `Token` keys for transactions where PayPal is the payment type. 

We reached out to PayPal support and they told us:
> You may see similar tokens returned for express checkout-based transactions as the token, (EC-abc123...) is used mutliple times throughout the transaction process, and it will be associated with all of them.  Every token will be unique to each transaction, so if you are seeing multiple identical tokens used for the same transaction, it is safe to ignore the duplicates.  

The logic is:
- If both are present and equal, keep `token` and drop `Token`
- If both are present and not equal, throw an error
- If only `Token` is present, convert `Token` -> `token`