### PR TITLE
Track http_request_timer metrics when calling the api

### DIFF
--- a/tap_shopify/streams/base.py
+++ b/tap_shopify/streams/base.py
@@ -1,13 +1,14 @@
-import math
-import functools
 import datetime
+import functools
+import math
 import sys
+
 import backoff
 import pyactiveresource
 import pyactiveresource.formats
 import simplejson
 import singer
-from singer import utils
+from singer import metrics, utils
 from tap_shopify.context import Context
 
 LOGGER = singer.get_logger()
@@ -150,7 +151,10 @@ class Stream():
                     "limit": results_per_page,
                     "status": "any"
                 }
-                objects = self.call_api(query_params)
+
+                with metrics.http_request_timer(self.name):
+                    objects = self.call_api(query_params)
+
                 for obj in objects:
                     if obj.id < since_id:
                         # This verifies the api behavior expectation we


### PR DESCRIPTION
Fixes #38

Tests passing and metrics recorded:

```
        2019-06-22 23:06:47,409Z    tap - INFO GET https://stitchdatawearhouse.myshopify.com/admin/products.json?status=any&updated_at_min=2019-06-04+20%3A14%3A08%2B00%3A00&since_id=1&updated_at_max=2019-06-22+23%3A06%3A45%2B00%3A00&limit=250
        2019-06-22 23:06:47,689Z    tap - INFO --> 200 OK 15b
        2019-06-22 23:06:47,690Z    tap - INFO METRIC Point(metric_type='timer', metric='http_request_duration', value=0.2817540168762207, tags={'endpoint': 'products', 'status': 'succeeded'})
```