### PR TITLE
Lower page size from 250 to 175

### DIFF
--- a/tap_shopify/streams/base.py
+++ b/tap_shopify/streams/base.py
@@ -13,7 +13,7 @@ from tap_shopify.context import Context
 
 LOGGER = singer.get_logger()
 
-RESULTS_PER_PAGE = 250
+RESULTS_PER_PAGE = 175
 
 # We've observed 500 errors returned if this is too large (30 days was too
 # large for a customer)


### PR DESCRIPTION
Lowering the page size from 250 to 175 as per recommendation from Shopify to mitigate receiving 500s.