### PR TITLE
Catch and backoff TimeoutErrors from urllib

### DIFF
--- a/tap_shopify/streams/base.py
+++ b/tap_shopify/streams/base.py
@@ -52,7 +52,7 @@ def retry_after_wait_gen(**kwargs):
 
 def shopify_error_handling(fnc):
     @backoff.on_exception(backoff.expo,
-                          (pyactiveresource.connection.ServerError,
+                          (pyactiveresource.connection.Error,
                            pyactiveresource.formats.Error,
                            simplejson.scanner.JSONDecodeError),
                           giveup=is_not_status_code_fn(range(500, 599)),


### PR DESCRIPTION
pyactiveresource wraps errors coming out of the underlying network libraries in an exception heirarchy of it's own. Before this change, we were catching `pyactiveresource.connection.ServerError`s and `pyactiveresource.connection.ClientError`s which caught the majority of the different things that could go wrong, but there's one base class that isn't caught by checks against either of those: `pyactiveresource.connection.Error`. As it turns out, that is what is thrown sometimes depending on the error coming up from `urllib`, like here: https://github.com/Shopify/pyactiveresource/blob/master/pyactiveresource/connection.py#L290

In the event of a socket layer `TimeoutError` (like the globally available one in Python 3), this is the error that's thrown, and before this change, `tap-shopify` wouldn't back off of those.

This changes `tap-shopify` to look for a 429 error first and implement the leaky bucket backoff behaviour, and then look for any `pyactiveresource.connection.Error`s after and exponentially backoff of those. This will include `pyactiveresource.connection.ServerError`s as `pyactiveresource.connection.ServerError` inherits from `pyactiveresource.connection.Error`, but also catch other classes of errors that can be retried.

:party: