### PR TITLE
Handle `results_per_page` that are None or not integers

### DIFF
--- a/tap_shopify/context.py
+++ b/tap_shopify/context.py
@@ -1,4 +1,7 @@
+import singer
 from singer import metadata
+
+LOGGER = singer.get_logger()
 
 class Context():
     config = {}
@@ -19,3 +22,20 @@ class Context():
         stream = cls.get_catalog_entry(stream_name)
         stream_metadata = metadata.to_map(stream['metadata'])
         return metadata.get(stream_metadata, (), 'selected')
+
+    @classmethod
+    def get_results_per_page(cls, default_results_per_page):
+        results_per_page = default_results_per_page
+        try:
+            results_per_page = int(cls.config.get("results_per_page"))
+        except TypeError:
+            # None value or no key
+            pass
+        except ValueError:
+            # non-int value
+            log_msg = ('Failed to parse results_per_page value of "%s" '
+            'as an integer, falling back to default of %d')
+            LOGGER.info(log_msg,
+                        Context.config['results_per_page'],
+                        default_results_per_page)
+        return results_per_page

--- a/tap_shopify/context.py
+++ b/tap_shopify/context.py
@@ -33,8 +33,8 @@ class Context():
             pass
         except ValueError:
             # non-int value
-            log_msg = ('Failed to parse results_per_page value of "%s" '
-            'as an integer, falling back to default of %d')
+            log_msg = ('Failed to parse results_per_page value of "%s" ' +
+                       'as an integer, falling back to default of %d')
             LOGGER.info(log_msg,
                         Context.config['results_per_page'],
                         default_results_per_page)

--- a/tap_shopify/streams/base.py
+++ b/tap_shopify/streams/base.py
@@ -125,7 +125,7 @@ class Stream():
 
         stop_time = singer.utils.now().replace(microsecond=0)
         date_window_size = float(Context.config.get("date_window_size", DATE_WINDOW_SIZE))
-        results_per_page = int(Context.config.get("results_per_page", RESULTS_PER_PAGE))
+        results_per_page = Context.get_results_per_page(RESULTS_PER_PAGE)
 
         # Page through till the end of the resultset
         while updated_at_min < stop_time:


### PR DESCRIPTION
# Description of change
Changes the tap to handle `results_per_page` values that are either `None` or not integers

# QA steps
 - [ ] automated tests passing
 - [x] manual qa steps passing
  - Cloned connection, replicated error and verified that this fixes it
 
# Risks

# Rollback steps
 - revert this branch
