### PR TITLE
Remove whitelist of receipt keys for canonicalize

### DIFF
--- a/tests/test_transaction_canonicalize.py
+++ b/tests/test_transaction_canonicalize.py
@@ -7,28 +7,28 @@ class TestTransactionCanonicalize(unittest.TestCase):
         # record to compare
         record = {"receipt": {"foo": "bar"}, "id": 2}
         expected_record = {"receipt": {"foo": "bar"}, "id": 2}
-        canonicalize(record, "token")
+        canonicalize(record)
         self.assertEqual(record, expected_record)
 
     def test_unmodified_if_only_lower_exists(self):
         record = {"receipt": {"foo": "bar"}, "id": 2}
         expected_record = {"receipt": {"foo": "bar"}, "id": 2}
-        canonicalize(record, "foo")
+        canonicalize(record)
         self.assertEqual(record, expected_record)
 
     def test_lowercases_if_capital_only_exists(self):
         record = {"receipt": {"Foo": "bar"}, "id": 2}
         expected_record = {"receipt": {"foo": "bar"}, "id": 2}
-        canonicalize(record, "foo")
+        canonicalize(record)
         self.assertEqual(record, expected_record)
 
     def test_removes_uppercase_if_both_exist_and_are_equal(self):
         record = {"receipt": {"Foo": "bar", "foo": "bar"}, "id": 2}
         expected_record = {"receipt": {"foo": "bar"}, "id": 2}
-        canonicalize(record, "foo")
+        canonicalize(record)
         self.assertEqual(record, expected_record)
 
     def test_throws_if_both_exist_and_are_not_equal(self):
         record = {"receipt": {"Foo": "bark", "foo": "bar"}, "id": 2}
         with self.assertRaises(ValueError):
-            canonicalize(record, "foo")
+            canonicalize(record)


### PR DESCRIPTION
# Description of change
Remove whitelist of receipt keys, update tests

# QA steps
 - [x] automated tests passing
 - [x] manual qa steps passing (list below)
    - Ran the unittests
# Risks
  - Low-Moderate: We know of 3 fields that can come back as lower+uppercased, but we and Shopify don't know of all of the possibilities

# Rollback steps
 - revert this branch
