### PR TITLE
[PLACEHOLDER] Update singer-python version.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     py_modules=["tap_shopify"],
     install_requires=[
         "ShopifyAPI==7.0.1",
-        "singer-python==5.4.1",
+        "singer-python==5.9.1",
     ],
     extras_require={
         'dev': [


### PR DESCRIPTION
# Description of change
This PR is intended to accompany the changes in https://github.com/singer-io/singer-python/pull/126. In short, Airflow 10.7 is dependent on `jsonschema >= 3.0.0`, and `singer-python` depends on `jsonschema==2.6.0`. However, as the version has not been updated yet, this PR stands to reduce later contribution efforts.

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch
