### PR TITLE
Add status param override for products stream

### DIFF
--- a/tap_shopify/streams/base.py
+++ b/tap_shopify/streams/base.py
@@ -84,6 +84,8 @@ class Stream():
     key_properties = ['id']
     # Controls which SDK object we use to call the API by default.
     replication_object = None
+    # Status parameter override option
+    status_key = None
 
     def get_bookmark(self):
         bookmark = (singer.get_bookmark(Context.state,
@@ -144,12 +146,13 @@ class Stream():
             if updated_at_max > stop_time:
                 updated_at_max = stop_time
             while True:
+                status_key = self.status_key or "status"
                 query_params = {
                     "since_id": since_id,
                     "updated_at_min": updated_at_min,
                     "updated_at_max": updated_at_max,
                     "limit": results_per_page,
-                    "status": "any"
+                    status_key: "any"
                 }
 
                 with metrics.http_request_timer(self.name):

--- a/tap_shopify/streams/products.py
+++ b/tap_shopify/streams/products.py
@@ -7,5 +7,6 @@ from tap_shopify.context import Context
 class Products(Stream):
     name = 'products'
     replication_object = shopify.Product
+    status_key = "published_status"
 
 Context.stream_objects['products'] = Products


### PR DESCRIPTION
# Description of change
It appears that Shopify has changed the parameter key from `status` to `published_status` for Products. This is currently resulting in 0 products being returned due to an implied bug on Shopify's end.

This PR makes this request parameter configurable, and implements an override for the `products` stream.

Given that [their documentation for the tap's version of the Products endpoint](https://shopify.dev/docs/admin-api/rest/reference/products/product?api[version]=2019-10#index-2019-10) now lists `published_status`, this seems like a much safer change

# QA steps
 - [x] manual qa steps passing (list below)
    - Ran through other streams to ensure that they were still getting records back
    - Ran through products with the old key of `status` and the new key `published_status` and confirmed that this gets that stream moving again.

# Risks
Medium-Low, effect on other streams should be minimal. However, this is a workaround for a Shopify issue, so it's slightly risky given that this changed without warning across all API versions.

# Rollback steps
 - revert this branch and release new patch version
