### PR TITLE
Update API and SDK version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     classifiers=["Programming Language :: Python :: 3 :: Only"],
     py_modules=["tap_shopify"],
     install_requires=[
-        "ShopifyAPI==7.0.1",
+        "ShopifyAPI==8.0.1",
         "singer-python==5.4.1",
     ],
     extras_require={

--- a/tap_shopify/__init__.py
+++ b/tap_shopify/__init__.py
@@ -20,7 +20,7 @@ LOGGER = singer.get_logger()
 def initialize_shopify_client():
     api_key = Context.config['api_key']
     shop = Context.config['shop']
-    version = '2019-10'
+    version = '2020-07'
     session = shopify.Session(shop, version, api_key)
     shopify.ShopifyResource.activate_session(session)
 


### PR DESCRIPTION
# Description of change
Update the version of the API and SDK to latest fully released versions (`2020-07` and `8.0.1` respectively)
The only difference between the API versions is that the `collects` stream no longer returns anything for `SmartCollections`, but we are not replicating the `SmartCollections` currently so the mapping of `product` -> `collection` for `SmartCollections`.

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks
 - Undiscovered differences between the API/SDK versions.

# Rollback steps
 - revert this branch
