### PR TITLE
add selected metadata field to discovery mode catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ This tap:
 
 5. Run the Tap in Sync Mode
 
+   Make sure to set the `selected` metadata field to true for streams that should sync. 
+
     tap-shopify -c config.json --catalog catalog-file.json
 
 ---

--- a/tap_shopify/__init__.py
+++ b/tap_shopify/__init__.py
@@ -46,6 +46,7 @@ def get_discovery_metadata(stream, schema):
     mdata = metadata.new()
     mdata = metadata.write(mdata, (), 'table-key-properties', stream.key_properties)
     mdata = metadata.write(mdata, (), 'forced-replication-method', stream.replication_method)
+    mdata = metadata.write(mdata, (), 'selected', False)
 
     if stream.replication_key:
         mdata = metadata.write(mdata, (), 'valid-replication-keys', [stream.replication_key])

--- a/tests/base.py
+++ b/tests/base.py
@@ -24,6 +24,7 @@ class BaseTapTest(unittest.TestCase):
     INCREMENTAL = "INCREMENTAL"
     FULL = "FULL_TABLE"
     START_DATE_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
+    SELECTED = "selected"
 
     @staticmethod
     def tap_name():
@@ -66,7 +67,8 @@ class BaseTapTest(unittest.TestCase):
                 self.REPLICATION_KEYS: {"updated_at"},
                 self.PRIMARY_KEYS: {"id"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
-                self.API_LIMIT: 250}
+                self.API_LIMIT: 250,
+                self.SELECTED: False}
 
         meta = default.copy()
         meta.update({self.FOREIGN_KEYS: {"owner_id", "owner_resource"}})
@@ -81,7 +83,8 @@ class BaseTapTest(unittest.TestCase):
                 self.REPLICATION_KEYS: {"created_at"},
                 self.PRIMARY_KEYS: {"id"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
-                self.API_LIMIT: 250},
+                self.API_LIMIT: 250,
+                self.SELECTED: False},
             "products": default,
             "metafields": meta,
             "transactions": {
@@ -89,7 +92,8 @@ class BaseTapTest(unittest.TestCase):
                 self.PRIMARY_KEYS: {"id"},
                 self.FOREIGN_KEYS: {"order_id"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
-                self.API_LIMIT: 250}
+                self.API_LIMIT: 250,
+                self.SELECTED: False}
         }
 
     def expected_streams(self):


### PR DESCRIPTION
# Description of change
This adds the selected attribute, set to false, to each stream's metadata fields. This is a helpful placeholder to use when choosing streams to export - just search for the stream name and then `selected` and set to true.

# QA steps
 - [ ] automated tests passing - No module named 'tap_tester' error locally - I think my modified tests will work.
 - [X] manual qa steps passing (list below)

Running the tap in discovery mode writes the new attribute to the metadata object for each stream. The field is set to false so there is no change in behavior. 

# Risks
Since the selected field is initialized to false, there is no change in behavior with discovery mode or the catalog it produces.

# Rollback steps
 - revert this branch