### PR TITLE
Minor change in customer schema definitions

### DIFF
--- a/tap_shopify/schemas/definitions.json
+++ b/tap_shopify/schemas/definitions.json
@@ -58,7 +58,10 @@
     ]
   },
   "customer": {
-    "type": "object",
+    "type": [
+      "null",
+      "object"
+    ],
     "properties": {
       "last_order_name": {
         "type": [


### PR DESCRIPTION
# Description of change
Just replaced the  type: "object" to the standard singer format i.e type:["null", "object"]

# QA steps
 - Tested by importing Shopify data to bigquery

 
# Risks
This was breaking the import pipeline

# Rollback steps
 - revert this branch
