### PR TITLE
add redirects stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.3.0
+  * Adds a `redirects` stream [#80] (https://github.com/singer-io/tap-shopify/pull/80)
+
 ## 1.2.6
   * Accepts any string for `accepts_marketing_updated_at` field on the `customers` stream [#69] (https://github.com/singer-io/tap-shopify/pull/69)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-shopify",
-    version="1.2.6",
+    version="1.3.0",
     description="Singer.io tap for extracting Shopify data",
     author="Stitch",
     url="http://github.com/singer-io/tap-shopify",

--- a/tap_shopify/schemas/redirects.json
+++ b/tap_shopify/schemas/redirects.json
@@ -1,0 +1,23 @@
+{
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "path": {
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      "target": {
+        "type": [
+          "null",
+          "string"
+        ]
+      }
+    }
+}

--- a/tap_shopify/streams/__init__.py
+++ b/tap_shopify/streams/__init__.py
@@ -7,3 +7,4 @@ import tap_shopify.streams.transactions
 import tap_shopify.streams.products
 import tap_shopify.streams.collects
 import tap_shopify.streams.custom_collections
+import tap_shopify.streams.redirects

--- a/tap_shopify/streams/redirects.py
+++ b/tap_shopify/streams/redirects.py
@@ -1,0 +1,41 @@
+import shopify
+from tap_shopify.streams.base import (Stream,
+                                      RESULTS_PER_PAGE,
+                                      OutOfOrderIdsError)
+from tap_shopify.context import Context
+
+
+class Redirects(Stream):
+    name = 'redirects'
+    replication_object = shopify.Redirect
+    # Redirects have no timestamps, but can be updated after creation
+    # So the only option is to use full table replication
+    replication_method = 'FULL_TABLE'
+    replication_key = 'id'
+
+    def get_objects(self):
+        # Override base function as this is a full sync every time
+        since_id = 1
+        while True:
+            query_params = {
+                "since_id": since_id,
+                "limit": RESULTS_PER_PAGE,
+            }
+
+            objects = self.call_api(query_params)
+
+            for obj in objects:
+                if obj.id < since_id:
+                    raise OutOfOrderIdsError("obj.id < since_id: {} < {}".format(
+                        obj.id, since_id))
+                yield obj
+
+            if len(objects) < RESULTS_PER_PAGE:
+                break
+            if objects[-1].id != max([o.id for o in objects]):
+                raise OutOfOrderIdsError("{} is not the max id in objects ({})".format(
+                    objects[-1].id, max([o.id for o in objects])))
+            since_id = objects[-1].id
+
+
+Context.stream_objects['redirects'] = Redirects


### PR DESCRIPTION
# Description of change
Adds a new redirects Stream to sync [Shopify Online-Store/Redirect](https://shopify.dev/docs/admin-api/rest/reference/online-store/redirect) data.

Because there are no timestamp properties on the Redirect data, I had to configure it as a full table replication and override the base `get_objects` function. I used the `collects` module as a template for this.

# QA steps
 - [ ] automated tests passing
 - [x] manual qa steps passing (list below)
   - Running the steps in the makefile individually works (for some reason I was getting an error when running `make test`)
   - Also got expected redirect data from an existing Shopify store, including when pagination was required.
 
# Risks
- This is my first development work on a tap, so it's possible I messed something up :-)

# Rollback steps
 - revert this branch
