### PR TITLE
Fix issue with empty types in orders

### DIFF
--- a/tap_shopify/schemas/orders.json
+++ b/tap_shopify/schemas/orders.json
@@ -6,12 +6,42 @@
           "string"
         ]
     },
-    "subtotal_price_set": {},
-    "total_discounts_set": {},
-    "total_line_items_price_set": {},
-    "total_price_set": {},
-    "total_shipping_price_set": {},
-    "total_tax_set": {},
+    "subtotal_price_set": {
+      "type": [
+        "null",
+        "object"
+      ]
+    },
+    "total_discounts_set": {
+      "type": [
+        "null",
+        "object"
+      ]
+    },
+    "total_line_items_price_set": {
+      "type": [
+        "null",
+        "object"
+      ]
+    },
+    "total_price_set": {
+      "type": [
+        "null",
+        "object"
+      ]
+    },
+    "total_shipping_price_set": {
+      "type": [
+        "null",
+        "object"
+      ]
+    },
+    "total_tax_set": {
+      "type": [
+        "null",
+        "object"
+      ]
+    },
     "total_price": {
       "type": [
         "null",


### PR DESCRIPTION
# Description of change
Fix will partly eliminate the issue with error of validating schema. It is referenced here: https://github.com/singer-io/tap-shopify/issues/78 and here https://github.com/transferwise/pipelinewise-target-snowflake/issues/140 I got the issue with orders schema (to make easy to google the resolution):

```
if 'string' in schema['properties'][key]['type'] and \
KeyError: 'type'
```

# QA steps
 - import data from shopify is working as expected
 
# Risks

# Rollback steps
 - revert this branch

P.S. It looks like the project is abadoned, so I'm doing the PR without hope to get it merged into master. Just to get an idea how to fix the issue.
