### PR TITLE
in schema, changed fields marked as numbers to singer.decimals

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,12 @@ jobs:
           command: |
             source /usr/local/share/virtualenvs/tap-shopify/bin/activate
             make test
+      - run:
+          name: 'JSON Validator'
+          command: |
+            source /usr/local/share/virtualenvs/tap-tester/bin/activate
+            stitch-validate-json /usr/local/share/virtualenvs/tap-shopify/lib/python3.5/site-packages/tap_shopify/schemas/*.json
+            stitch-validate-json /usr/local/share/virtualenvs/tap-shopify/lib/python3.5/site-packages/tap_shopify/schemas/shared/*.json
       - add_ssh_keys
       - run:
           name: 'Integration Tests'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,6 @@ jobs:
           command: |
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             stitch-validate-json /usr/local/share/virtualenvs/tap-shopify/lib/python3.5/site-packages/tap_shopify/schemas/*.json
-            stitch-validate-json /usr/local/share/virtualenvs/tap-shopify/lib/python3.5/site-packages/tap_shopify/schemas/shared/*.json
       - add_ssh_keys
       - run:
           name: 'Integration Tests'

--- a/tap_shopify/schemas/abandoned_checkouts.json
+++ b/tap_shopify/schemas/abandoned_checkouts.json
@@ -66,8 +66,9 @@
         "latitude": {
           "type": [
             "null",
-            "number"
-          ]
+            "string"
+          ],
+          "format": "singer.decimal"
         },
         "zip": {
           "type": [
@@ -126,8 +127,9 @@
         "longitude": {
           "type": [
             "null",
-            "number"
-          ]
+            "string"
+          ],
+          "format": "singer.decimal"
         }
       }
     },
@@ -157,9 +159,9 @@
           "amount": {
             "type": [
               "null",
-              "number"
+              "string"
             ],
-            "multipleOf": 1e-10
+            "format": "singer.decimal"
           },
           "code": {
             "type": [
@@ -220,9 +222,9 @@
     "total_line_items_price": {
       "type": [
         "null",
-        "number"
+        "string"
       ],
-      "multipleOf": 1e-10
+      "format": "singer.decimal"
     },
     "closed_at": {
       "type": [
@@ -264,16 +266,16 @@
     "total_tax": {
       "type": [
         "null",
-        "number"
+        "string"
       ],
-      "multipleOf": 1e-10
+      "format": "singer.decimal"
     },
     "subtotal_price": {
       "type": [
         "null",
-        "number"
+        "string"
       ],
-      "multipleOf": 1e-10
+      "format": "singer.decimal"
     },
     "line_items": {
       "$ref": "definitions.json#/line_items"
@@ -287,9 +289,9 @@
     "total_discounts": {
       "type": [
         "null",
-        "number"
+        "string"
       ],
-      "multipleOf": 1e-10
+      "format": "singer.decimal"
     },
     "note": {
       "type": [
@@ -349,9 +351,9 @@
           "price": {
             "type": [
               "null",
-              "number"
+              "string"
             ],
-            "multipleOf": 1e-10
+            "format": "singer.decimal"
           },
           "requested_fulfillment_service_id": {
             "type": [
@@ -446,8 +448,9 @@
         "latitude": {
           "type": [
             "null",
-            "number"
-          ]
+            "string"
+          ],
+          "format": "singer.decimal"
         },
         "zip": {
           "type": [
@@ -506,8 +509,9 @@
         "longitude": {
           "type": [
             "null",
-            "number"
-          ]
+            "string"
+          ],
+          "format": "singer.decimal"
         }
       }
     },
@@ -529,9 +533,9 @@
     "total_price": {
       "type": [
         "null",
-        "number"
+        "string"
       ],
-      "multipleOf": 1e-10
+      "format": "singer.decimal"
     },
     "cart_token": {
       "type": [

--- a/tap_shopify/schemas/definitions.json
+++ b/tap_shopify/schemas/definitions.json
@@ -11,9 +11,9 @@
         "tax_amount": {
           "type": [
             "null",
-            "number"
+            "string"
           ],
-          "multipleOf": 1e-10
+          "format": "singer.decimal"
         },
         "refund_id": {
           "type": [
@@ -24,9 +24,9 @@
         "amount": {
           "type": [
             "null",
-            "number"
+            "string"
           ],
-          "multipleOf": 1e-10
+          "format": "singer.decimal"
         },
         "kind": {
           "type": [
@@ -593,8 +593,9 @@
             "amount": {
               "type": [
                 "null",
-                "number"
-              ]
+                "string"
+              ],
+              "format": "singer.decimal"
             }
           },
           "type": [
@@ -616,8 +617,9 @@
       "pre_tax_price": {
         "type": [
           "null",
-          "number"
-        ]
+          "string"
+        ],
+        "format": "singer.decimal"
       },
       "sku": {
         "type": [
@@ -634,9 +636,9 @@
       "total_discount": {
         "type": [
           "null",
-          "number"
+          "string"
         ],
-        "multipleOf": 1e-10
+        "format": "singer.decimal"
       },
       "name": {
         "type": [
@@ -680,9 +682,9 @@
       "price": {
         "type": [
           "null",
-          "number"
+          "string"
         ],
-        "multipleOf": 1e-10
+        "format": "singer.decimal"
       },
       "requires_shipping": {
         "type": [
@@ -828,9 +830,9 @@
         "price": {
           "type": [
             "null",
-            "number"
+            "string"
           ],
-          "multipleOf": 1e-10
+          "format": "singer.decimal"
         },
         "title": {
           "type": [
@@ -841,9 +843,9 @@
         "rate": {
           "type": [
             "null",
-            "number"
+            "string"
           ],
-          "multipleOf": 1e-10
+          "format": "singer.decimal"
         },
         "compare_at": {
           "type": [

--- a/tap_shopify/schemas/order_refunds.json
+++ b/tap_shopify/schemas/order_refunds.json
@@ -168,8 +168,9 @@
           "total_tax": {
             "type": [
               "null",
-              "number"
-            ]
+              "string"
+            ],
+            "format": "singer.decimal"
           },
           "quantity": {
             "type": [
@@ -268,7 +269,8 @@
                       "type": [
                         "null",
                         "number"
-                      ]
+                      ],
+                      "format": "singer.decimal"
                     }
                   },
                   "type": [
@@ -650,8 +652,9 @@
           "subtotal": {
             "type": [
               "null",
-              "number"
-            ]
+              "string"
+            ],
+            "format": "singer.decimal"
           },
           "restock_type": {
             "type": [

--- a/tap_shopify/schemas/order_refunds.json
+++ b/tap_shopify/schemas/order_refunds.json
@@ -268,7 +268,7 @@
                     "rate": {
                       "type": [
                         "null",
-                        "number"
+                        "string"
                       ],
                       "format": "singer.decimal"
                     }

--- a/tap_shopify/schemas/orders.json
+++ b/tap_shopify/schemas/orders.json
@@ -1,4 +1,4 @@
-{
+ {
   "properties": {
     "presentment_currency": {
         "type": [
@@ -15,9 +15,9 @@
     "total_price": {
       "type": [
         "null",
-        "number"
+        "string"
       ],
-      "multipleOf": 1e-10
+      "format": "singer.decimal"
     },
     "line_items": {
       "$ref": "definitions.json#/line_items"
@@ -43,16 +43,16 @@
     "total_discounts": {
       "type": [
         "null",
-        "number"
+        "string"
       ],
-      "multipleOf": 1e-10
+      "format": "singer.decimal"
     },
     "total_line_items_price": {
       "type": [
         "null",
-        "number"
+        "string"
       ],
-      "multipleOf": 1e-10
+      "format": "singer.decimal"
     },
     "order_adjustments": {
       "$ref": "definitions.json#/order_adjustments"
@@ -74,9 +74,9 @@
           "price": {
             "type": [
               "null",
-              "number"
+              "string"
             ],
-            "multipleOf": 1e-10
+            "format": "singer.decimal"
           },
           "title": {
             "type": [
@@ -96,8 +96,9 @@
                 "amount": {
                   "type": [
                     "null",
-                    "number"
-                  ]
+                    "string"
+                  ],
+                  "format": "singer.decimal"
                 }
               },
               "type": [
@@ -119,8 +120,9 @@
           "discounted_price": {
             "type": [
               "null",
-              "number"
-            ]
+              "string"
+            ],
+            "format": "singer.decimal"
           },
           "code": {
             "type": [
@@ -374,9 +376,9 @@
     "total_tax": {
       "type": [
         "null",
-        "number"
+        "string"
       ],
-      "multipleOf": 1e-10
+      "format": "singer.decimal"
     },
     "payment_details": {
       "properties": {
@@ -469,8 +471,9 @@
         "longitude": {
           "type": [
             "null",
-            "number"
-          ]
+            "string"
+          ],
+          "format": "singer.decimal"
         },
         "address2": {
           "type": [
@@ -511,8 +514,9 @@
         "latitude": {
           "type": [
             "null",
-            "number"
-          ]
+            "string"
+          ],
+          "format": "singer.decimal"
         },
         "country_code": {
           "type": [
@@ -541,9 +545,9 @@
     "total_price_usd": {
       "type": [
         "null",
-        "number"
+        "string"
       ],
-      "multipleOf": 1e-10
+      "format": "singer.decimal"
     },
     "closed_at": {
       "type": [
@@ -606,8 +610,9 @@
           "value": {
             "type": [
               "null",
-              "number"
-            ]
+              "string"
+            ],
+            "format": "singer.decimal"
           }
         },
         "type": [
@@ -647,9 +652,9 @@
     "subtotal_price": {
       "type": [
         "null",
-        "number"
+        "string"
       ],
-      "multipleOf": 1e-10
+      "format": "singer.decimal"
     },
     "billing_address": {
       "properties": {
@@ -680,8 +685,9 @@
         "longitude": {
           "type": [
             "null",
-            "number"
-          ]
+            "string"
+          ],
+          "format": "singer.decimal"
         },
         "address2": {
           "type": [
@@ -722,8 +728,9 @@
         "latitude": {
           "type": [
             "null",
-            "number"
-          ]
+            "string"
+          ],
+          "format": "singer.decimal"
         },
         "country_code": {
           "type": [
@@ -797,9 +804,9 @@
           "amount": {
             "type": [
               "null",
-              "number"
+              "string"
             ],
-            "multipleOf": 1e-10
+            "format": "singer.decimal"
           },
           "type": {
             "type": [
@@ -1012,8 +1019,9 @@
                 "total_tax": {
                   "type": [
                     "null",
-                    "number"
-                  ]
+                    "string"
+                  ],
+                  "format": "singer.decimal"
                 },
                 "restock_type": {
                   "type": [
@@ -1024,8 +1032,9 @@
                 "subtotal": {
                   "type": [
                     "null",
-                    "number"
-                  ]
+                    "string"
+                  ],
+                  "format": "singer.decimal"
                 }
               },
               "type": [

--- a/tap_shopify/schemas/products.json
+++ b/tap_shopify/schemas/products.json
@@ -178,9 +178,9 @@
           "price": {
             "type": [
               "null",
-              "number"
+              "string"
             ],
-            "multipleOf": 1e-10
+            "format": "singer.decimal"
           },
           "image_id": {
             "type": [
@@ -221,8 +221,9 @@
           "weight": {
             "type": [
               "null",
-              "number"
-            ]
+              "string"
+            ],
+            "format": "singer.decimal"
           },
           "inventory_management": {
             "type": [
@@ -251,9 +252,9 @@
           "compare_at_price": {
             "type": [
               "null",
-              "number"
+              "string"
             ],
-            "multipleOf": 1e-10
+            "format": "singer.decimal"
           },
           "updated_at": {
             "type": [

--- a/tap_shopify/schemas/transactions.json
+++ b/tap_shopify/schemas/transactions.json
@@ -45,9 +45,9 @@
     "amount": {
       "type": [
         "null",
-        "number"
+        "string"
       ],
-      "multipleOf": 1e-10
+      "format": "singer.decimal"
     },
     "authorization": {
       "type": [
@@ -150,23 +150,23 @@
         "fee_amount": {
           "type": [
             "null",
-            "number"
+            "string"
           ],
-          "multipleOf": 1e-10
+          "format": "singer.decimal"
         },
         "gross_amount": {
           "type": [
             "null",
-            "number"
+            "string"
           ],
-          "multipleOf": 1e-10
+          "format": "singer.decimal"
         },
         "tax_amount": {
           "type": [
             "null",
-            "number"
+            "string"
           ],
-          "multipleOf": 1e-10
+          "format": "singer.decimal"
         }
       },
       "patternProperties": {".+": {}}


### PR DESCRIPTION
# Description of change
in schema, changed fields marked as numbers to singer.decimals

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
- looked at how a field passes through the transformer when it's type was marked as a number, multipleOf=10 and when it's type was marked as a singer.decimal
```WITH SCHEMA AS NUMBER, MULTIPLEOF
ipdb> rec['total_price']
'0.480908943890432809980384903809423809489043890'
ipdb> unt 152
*rec passes through transformer *
ipdb> rec['total_price']
0.4809089438904328

WITH SCHEMA AS STRING, SINGER.DECIMAL
ipdb> rec['total_price']
'0.480908943890432809980384903809423809489043890'
ipdb> unt 152
*rec passes through transformer *
ipdb> rec['total_price']
'0.4809089438904328099803849038'
```
# Risks
low

# Rollback steps
 - revert this branch
