### PR TITLE
Should parse json string flag

### DIFF
--- a/tap_shopify/streams/metafields.py
+++ b/tap_shopify/streams/metafields.py
@@ -30,7 +30,7 @@ class Metafields(Stream):
 
     def __init__(self, *args, **kwargs):
         super(*args, **kwargs)
-        self.should_parse_json_string = Context.config.get('should_parse_json_string', True)
+        self.should_parse_json_string = Context.config.get('metafields_value_should_parse_json_string', True)
 
     def get_objects(self):
         # Get top-level shop metafields

--- a/tap_shopify/streams/metafields.py
+++ b/tap_shopify/streams/metafields.py
@@ -26,6 +26,11 @@ def get_metafields(parent_object, since_id):
 class Metafields(Stream):
     name = 'metafields'
     replication_object = shopify.Metafield
+    should_parse_json_string = None
+
+    def __init__(self, *args, **kwargs):
+        super(*args, **kwargs)
+        self.should_parse_json_string = Context.config.get('should_parse_json_string', True)
 
     def get_objects(self):
         # Get top-level shop metafields
@@ -58,7 +63,7 @@ class Metafields(Stream):
         for metafield in self.get_objects():
             metafield = metafield.to_dict()
             value_type = metafield.get("value_type")
-            if value_type and value_type == "json_string":
+            if self.should_parse_json_string and value_type and value_type == "json_string":
                 value = metafield.get("value")
                 try:
                     metafield["value"] = json.loads(value) if value is not None else value


### PR DESCRIPTION
# Description of change
As discussed https://github.com/singer-io/tap-shopify/issues/92

This allows users to opt-out of the metafield.value "parse json_string" behavior. I needed this because my desired target (singer-target-postgres) did not support a single field being int/string/object.

The Shopify API returns a string field, this feature lets the user keep it a string.

# QA steps
 - [x] automated tests passing
 - [x] manual qa steps passing (list below)
 
I've been running this locally against our live Shopify store. I've observed it correctly working (keeping metafield.value as a string type when metafield.value_type is json_string). I've observed this allowing this shopify value to end up in my postgres db via singer-target-postgres, solving my problem.

# Risks

This adds a small amount of surface area to the code, but this doesn't appear to interact with anything else in the program.

# Rollback steps
 - revert this branch
