### PR TITLE
bump to 2021-04

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     classifiers=["Programming Language :: Python :: 3 :: Only"],
     py_modules=["tap_shopify"],
     install_requires=[
-        "ShopifyAPI==8.0.1",
+        "ShopifyAPI==8.4.1",
         "singer-python==5.12.1",
     ],
     extras_require={

--- a/tap_shopify/__init__.py
+++ b/tap_shopify/__init__.py
@@ -21,7 +21,7 @@ LOGGER = singer.get_logger()
 def initialize_shopify_client():
     api_key = Context.config['api_key']
     shop = Context.config['shop']
-    version = '2020-07'
+    version = '2021-04'
     session = shopify.Session(shop, version, api_key)
     shopify.ShopifyResource.activate_session(session)
 


### PR DESCRIPTION
# Description of change
this bumps past 2020-10 and 2021-01 to 2021-04

# QA steps
 - [X] automated tests passing
    -  Because #97 was merged, we can test this upgrade against all streams
 - [X] manual qa steps passing (list below)
     - We combed over the changelog and couldn't find any changes relevant to the tap
 
 
# Risks
low

# Rollback steps
 - revert this branch
