### PR TITLE
Get tests passing on all streams

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     ],
     extras_require={
         'dev': [
-            'pylint',
+            'pylint==2.7.4',
             'ipdb',
             'requests==2.20.0',
             'nose',

--- a/tap_shopify/streams/order_refunds.py
+++ b/tap_shopify/streams/order_refunds.py
@@ -1,11 +1,10 @@
 import shopify
-
+from singer.utils import strftime, strptime_to_utc
 from tap_shopify.context import Context
 from tap_shopify.streams.base import (Stream,
                                       RESULTS_PER_PAGE,
                                       shopify_error_handling,
                                       OutOfOrderIdsError)
-from singer.utils import strftime, strptime_to_utc
 
 class OrderRefunds(Stream):
     name = 'order_refunds'

--- a/tap_shopify/streams/transactions.py
+++ b/tap_shopify/streams/transactions.py
@@ -65,8 +65,13 @@ class Transactions(Stream):
         # support limit overrides.
         #
         # https://github.com/Shopify/shopify_python_api/blob/e8c475ccc84b1516912b37f691d00ecd24921e9b/shopify/resources/order.py#L17-L18
-        return self.replication_object.find(
-            limit=TRANSACTIONS_RESULTS_PER_PAGE, order_id=parent_object.id)
+
+        page = self.replication_object.find(limit=TRANSACTIONS_RESULTS_PER_PAGE, order_id=parent_object.id)
+        yield from page
+
+        while page.has_next_page():
+            page = page.next_page()
+            yield from page
 
     def get_objects(self):
         # Right now, it's ok for the user to select 'transactions' but not

--- a/tap_shopify/streams/transactions.py
+++ b/tap_shopify/streams/transactions.py
@@ -57,8 +57,11 @@ class Transactions(Stream):
     # https://help.shopify.com/en/api/reference/orders/transaction#properties
 
     @shopify_error_handling
-    def call_api(self, parent_object):
-        return self.replication_object.find(limit=TRANSACTIONS_RESULTS_PER_PAGE, order_id=parent_object.id)
+    def call_api_for_transactions(self, parent_object):
+        return self.replication_object.find(
+            limit=TRANSACTIONS_RESULTS_PER_PAGE,
+            order_id=parent_object.id,
+        )
 
     def get_transactions(self, parent_object):
         # We do not need to support paging on this substream. If that
@@ -70,7 +73,7 @@ class Transactions(Stream):
         #
         # https://github.com/Shopify/shopify_python_api/blob/e8c475ccc84b1516912b37f691d00ecd24921e9b/shopify/resources/order.py#L17-L18
 
-        page = self.call_api(parent_object)
+        page = self.call_api_for_transactions(parent_object)
         yield from page
 
         while page.has_next_page():

--- a/tap_shopify/streams/transactions.py
+++ b/tap_shopify/streams/transactions.py
@@ -56,6 +56,9 @@ class Transactions(Stream):
     # https://help.shopify.com/en/api/reference/orders/transaction#properties
 
     @shopify_error_handling
+    def call_api(self, parent_object):
+        return self.replication_object.find(limit=TRANSACTIONS_RESULTS_PER_PAGE, order_id=parent_object.id)
+
     def get_transactions(self, parent_object):
         # We do not need to support paging on this substream. If that
         # were to become untrue, reference Metafields.
@@ -66,7 +69,7 @@ class Transactions(Stream):
         #
         # https://github.com/Shopify/shopify_python_api/blob/e8c475ccc84b1516912b37f691d00ecd24921e9b/shopify/resources/order.py#L17-L18
 
-        page = self.replication_object.find(limit=TRANSACTIONS_RESULTS_PER_PAGE, order_id=parent_object.id)
+        page = self.call_api(parent_object)
         yield from page
 
         while page.has_next_page():

--- a/tests/base.py
+++ b/tests/base.py
@@ -24,6 +24,7 @@ class BaseTapTest(unittest.TestCase):
     INCREMENTAL = "INCREMENTAL"
     FULL = "FULL_TABLE"
     START_DATE_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
+    DEFAULT_RESULTS_PER_PAGE = 175
 
     @staticmethod
     def tap_name():
@@ -41,6 +42,7 @@ class BaseTapTest(unittest.TestCase):
             'start_date': '2017-07-01T00:00:00Z',
             'shop': 'stitchdatawearhouse',
             'date_window_size': 30,
+            # BUG: https://jira.talendforge.org/browse/TDL-13180
             'results_per_page': '50'
         }
 
@@ -57,6 +59,7 @@ class BaseTapTest(unittest.TestCase):
     @staticmethod
     def get_credentials(original_credentials: bool = True):
         """Authentication information for the test account"""
+
         if original_credentials:
             return {
                 'api_key': os.getenv('TAP_SHOPIFY_API_KEY_STITCHDATAWEARHOUSE')
@@ -73,7 +76,7 @@ class BaseTapTest(unittest.TestCase):
                 self.REPLICATION_KEYS: {"updated_at"},
                 self.PRIMARY_KEYS: {"id"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
-                self.API_LIMIT: 175}
+                self.API_LIMIT: self.DEFAULT_RESULTS_PER_PAGE}
 
         meta = default.copy()
         meta.update({self.FOREIGN_KEYS: {"owner_id", "owner_resource"}})
@@ -83,6 +86,7 @@ class BaseTapTest(unittest.TestCase):
                 self.REPLICATION_KEYS: {"updated_at"},
                 self.PRIMARY_KEYS: {"id"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
+                # BUG: https://jira.talendforge.org/browse/TDL-13180
                 self.API_LIMIT: 50},
             "collects": default,
             "custom_collections": default,
@@ -92,7 +96,7 @@ class BaseTapTest(unittest.TestCase):
                 self.REPLICATION_KEYS: {"created_at"},
                 self.PRIMARY_KEYS: {"id"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
-                self.API_LIMIT: 175},
+                self.API_LIMIT: self.DEFAULT_RESULTS_PER_PAGE},
             "products": default,
             "metafields": meta,
             "transactions": {
@@ -100,7 +104,7 @@ class BaseTapTest(unittest.TestCase):
                 self.PRIMARY_KEYS: {"id"},
                 self.FOREIGN_KEYS: {"order_id"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
-                self.API_LIMIT: 100}
+                self.API_LIMIT: self.DEFAULT_RESULTS_PER_PAGE}
         }
 
     def expected_streams(self):

--- a/tests/base.py
+++ b/tests/base.py
@@ -272,3 +272,5 @@ class BaseTapTest(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.start_date = self.get_properties().get("start_date")
+        self.store_1_streams = {'custom_collections', 'orders', 'products', 'customers'}
+        self.store_2_streams = {'abandoned_checkouts', 'collects', 'metafields', 'transactions', 'order_refunds', 'products'}

--- a/tests/base.py
+++ b/tests/base.py
@@ -59,7 +59,7 @@ class BaseTapTest(unittest.TestCase):
         """Authentication information for the test account"""
         if original_credentials:
             return {
-            'api_key': os.getenv('TAP_SHOPIFY_API_KEY_1')
+                'api_key': os.getenv('TAP_SHOPIFY_API_KEY_1')
             }
 
         return {

--- a/tests/base.py
+++ b/tests/base.py
@@ -59,11 +59,11 @@ class BaseTapTest(unittest.TestCase):
         """Authentication information for the test account"""
         if original_credentials:
             return {
-                'api_key': os.getenv('TAP_SHOPIFY_API_KEY_1')
+                'api_key': os.getenv('TAP_SHOPIFY_API_KEY_STITCHDATAWEARHOUSE')
             }
 
         return {
-            'api_key': os.getenv('TAP_SHOPIFY_API_KEY_2')
+            'api_key': os.getenv('TAP_SHOPIFY_API_KEY_TALENDDATAWEARHOUSE')
         }
 
     def expected_metadata(self):
@@ -151,7 +151,8 @@ class BaseTapTest(unittest.TestCase):
     def setUp(self):
         """Verify that you have set the prerequisites to run the tap (creds, etc.)"""
         missing_envs = [x
-                        for x in [os.getenv('TAP_SHOPIFY_API_KEY_1'), os.getenv('TAP_SHOPIFY_API_KEY_2')]
+                        for x in [os.getenv('TAP_SHOPIFY_API_KEY_STITCHDATAWEARHOUSE'),
+                                  os.getenv('TAP_SHOPIFY_API_KEY_TALENDDATAWEARHOUSE')]
                         if x is None]
         if missing_envs:
             raise Exception("set environment variables")

--- a/tests/test_automatic_fields.py
+++ b/tests/test_automatic_fields.py
@@ -59,9 +59,14 @@ class MinimumSelectionTest(BaseTapTest):
                 # verify that you get more than a page of data
                 # SKIP THIS ASSERTION FOR STREAMS WHERE YOU CANNOT GET
                 # MORE THAN 1 PAGE OF DATA IN THE TEST ACCOUNT
+                stream_metadata = self.expected_metadata().get(stream, {})
+                minimum_record_count = stream_metadata.get(
+                    self.API_LIMIT,
+                    self.get_properties().get('result_per_page', self.DEFAULT_RESULTS_PER_PAGE)
+                )
                 self.assertGreater(
                     record_count_by_stream.get(stream, -1),
-                    self.expected_metadata().get(stream, {}).get(self.API_LIMIT, 0),
+                    minimum_record_count,
                     msg="The number of records is not over the stream max limit")
 
                 # verify that only the automatic fields are sent to the target

--- a/tests/test_automatic_fields.py
+++ b/tests/test_automatic_fields.py
@@ -14,7 +14,20 @@ class MinimumSelectionTest(BaseTapTest):
     def name():
         return "tap_tester_shopify_no_fields_test"
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.start_date = '2021-04-01T00:00:00Z'
+
     def test_run(self):
+        with self.subTest(store="store_1"):
+            conn_id = self.create_connection(original_credentials=True)
+            self.automatic_test(conn_id, self.store_1_streams)
+
+        with self.subTest(store="store_2"):
+            conn_id = self.create_connection(original_properties=False, original_credentials=False)
+            self.automatic_test(conn_id, self.store_2_streams)
+
+    def automatic_test(self, conn_id, testable_streams):
         """
         Verify that for each stream you can get multiple pages of data
         when no fields are selected and only the automatic fields are replicated.
@@ -24,19 +37,15 @@ class MinimumSelectionTest(BaseTapTest):
         fetch of data.  For instance if you have a limit of 250 records ensure
         that 251 (or more) records have been posted for that stream.
         """
-        conn_id = self.create_connection()
-
         incremental_streams = {key for key, value in self.expected_replication_method().items()
-                               if value == self.INCREMENTAL}
+                               if value == self.INCREMENTAL and key in testable_streams}
 
         # Select all streams and no fields within streams
         # IF THERE ARE NO AUTOMATIC FIELDS FOR A STREAM
         # WE WILL NEED TO UPDATE THE BELOW TO SELECT ONE
         found_catalogs = menagerie.get_catalogs(conn_id)
-        untested_streams = self.child_streams().union({'abandoned_checkouts', 'collects', 'metafields', 'transactions', 'order_refunds'})
         our_catalogs = [catalog for catalog in found_catalogs if
-                        catalog.get('tap_stream_id') in incremental_streams.difference(
-                            untested_streams)]
+                        catalog.get('tap_stream_id') in incremental_streams]
         self.select_all_streams_and_fields(conn_id, our_catalogs, select_all_fields=False)
 
         # Run a sync job using orchestrator
@@ -44,7 +53,7 @@ class MinimumSelectionTest(BaseTapTest):
 
         actual_fields_by_stream = runner.examine_target_output_for_fields()
 
-        for stream in self.expected_streams().difference(untested_streams):
+        for stream in incremental_streams:
             with self.subTest(stream=stream):
 
                 # verify that you get more than a page of data
@@ -59,7 +68,6 @@ class MinimumSelectionTest(BaseTapTest):
                 self.assertEqual(
                     actual_fields_by_stream.get(stream, set()),
                     self.expected_primary_keys().get(stream, set()) |
-                    self.expected_replication_keys().get(stream, set()) |
-                    self.expected_foreign_keys().get(stream, set()),
+                    self.expected_replication_keys().get(stream, set()),
                     msg="The fields sent to the target are not the automatic fields"
                 )

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -20,11 +20,13 @@ class BookmarkTest(BaseTapTest):
         self.start_date = '2021-04-01T00:00:00Z'
 
     def test_run(self):
-        conn_id = self.create_connection(original_credentials=True)
-        self.bookmarks_test(conn_id, self.store_1_streams)
+        with self.subTest(store="store_1"):
+            conn_id = self.create_connection(original_credentials=True)
+            self.bookmarks_test(conn_id, self.store_1_streams)
 
-        conn_id = self.create_connection(original_properties=False, original_credentials=False)
-        self.bookmarks_test(conn_id, self.store_2_streams)
+        with self.subTest(store="store_2"):
+            conn_id = self.create_connection(original_properties=False, original_credentials=False)
+            self.bookmarks_test(conn_id, self.store_2_streams)
 
     def bookmarks_test(self, conn_id, testable_streams):
         """

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -15,7 +15,18 @@ class BookmarkTest(BaseTapTest):
     def name():
         return "tap_tester_shopify_bookmark_test"
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.start_date = '2021-04-01T00:00:00Z'
+
     def test_run(self):
+        conn_id = self.create_connection(original_credentials=True)
+        self.bookmarks_test(conn_id, self.store_1_streams)
+
+        conn_id = self.create_connection(original_properties=False, original_credentials=False)
+        self.bookmarks_test(conn_id, self.store_2_streams)
+
+    def bookmarks_test(self, conn_id, testable_streams):
         """
         Verify that for each stream you can do a sync which records bookmarks.
         That the bookmark is the maximum value sent to the target for the replication key.
@@ -32,18 +43,15 @@ class BookmarkTest(BaseTapTest):
         For EACH stream that is incrementally replicated there are multiple rows of data with
             different values for the replication key
         """
-        conn_id = self.create_connection()
 
         # Select all streams and no fields within streams
         found_catalogs = menagerie.get_catalogs(conn_id)
         incremental_streams = {key for key, value in self.expected_replication_method().items()
-                               if value == self.INCREMENTAL}
+                               if value == self.INCREMENTAL and key in testable_streams}
 
         # Our test data sets for Shopify do not have any abandoned_checkouts
-        untested_streams = self.child_streams().union({'abandoned_checkouts', 'collects', 'metafields', 'transactions', 'order_refunds'})
         our_catalogs = [catalog for catalog in found_catalogs if
-                        catalog.get('tap_stream_id') in incremental_streams.difference(
-                            untested_streams)]
+                        catalog.get('tap_stream_id') in incremental_streams]
         self.select_all_streams_and_fields(conn_id, our_catalogs, select_all_fields=False)
 
         # Run a sync job using orchestrator
@@ -51,7 +59,7 @@ class BookmarkTest(BaseTapTest):
 
         # verify that the sync only sent records to the target for selected streams (catalogs)
         self.assertEqual(set(first_sync_record_count.keys()),
-                         incremental_streams.difference(untested_streams))
+                         incremental_streams)
 
         first_sync_state = menagerie.get_state(conn_id)
 
@@ -69,7 +77,7 @@ class BookmarkTest(BaseTapTest):
 
         # THIS MAKES AN ASSUMPTION THAT CHILD STREAMS DO NOT HAVE BOOKMARKS.
         # ADJUST IF NECESSARY
-        for stream in incremental_streams.difference(untested_streams):
+        for stream in incremental_streams:
             with self.subTest(stream=stream):
 
                 # get bookmark values from state and target data

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -18,13 +18,11 @@ class PaginationTest(BaseTapTest):
 
 
     def test_run(self):
-        # conn_id = self.create_connection(original_credentials=True)
-        testable_streams = {'custom_collections', 'orders', 'products', 'customers'}
-        # self.pagination_test(conn_id, testable_streams)
+        conn_id = self.create_connection(original_credentials=True)
+        self.pagination_test(conn_id, self.store_1_streams)
 
         conn_id = self.create_connection(original_properties=False, original_credentials=False)
-        testable_streams = {'abandoned_checkouts', 'collects', 'metafields', 'transactions', 'order_refunds', 'products'}
-        self.pagination_test(conn_id, testable_streams)
+        self.pagination_test(conn_id, self.store_2_streams)
 
     
     def pagination_test(self, conn_id, testable_streams):
@@ -37,12 +35,11 @@ class PaginationTest(BaseTapTest):
         fetch of data.  For instance if you have a limit of 250 records ensure
         that 251 (or more) records have been posted for that stream.
         """
-        conn_id = self.create_connection()
 
         # Select all streams and all fields within streams
         found_catalogs = menagerie.get_catalogs(conn_id)
         incremental_streams = {key for key, value in self.expected_replication_method().items()
-                               if value == self.INCREMENTAL}
+                               if value == self.INCREMENTAL and key in testable_streams}
 
 
         # our_catalogs = [catalog for catalog in found_catalogs if

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -18,11 +18,13 @@ class PaginationTest(BaseTapTest):
 
 
     def test_run(self):
-        conn_id = self.create_connection(original_credentials=True)
-        self.pagination_test(conn_id, self.store_1_streams)
+        with self.subTest(store="store_1"):
+            conn_id = self.create_connection(original_credentials=True)
+            self.pagination_test(conn_id, self.store_1_streams)
 
-        conn_id = self.create_connection(original_properties=False, original_credentials=False)
-        self.pagination_test(conn_id, self.store_2_streams)
+        with self.subTest(store="store_2"):
+            conn_id = self.create_connection(original_properties=False, original_credentials=False)
+            self.pagination_test(conn_id, self.store_2_streams)
 
     
     def pagination_test(self, conn_id, testable_streams):

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -60,9 +60,14 @@ class PaginationTest(BaseTapTest):
             with self.subTest(stream=stream):
 
                 # verify that we can paginate with all fields selected
+                stream_metadata = self.expected_metadata().get(stream, {})
+                minimum_record_count = stream_metadata.get(
+                    self.API_LIMIT,
+                    self.get_properties().get('result_per_page', self.DEFAULT_RESULTS_PER_PAGE)
+                )
                 self.assertGreater(
                     record_count_by_stream.get(stream, -1),
-                    self.expected_metadata().get(stream, {}).get(self.API_LIMIT, 0),
+                    minimum_record_count,
                     msg="The number of records is not over the stream max limit")
 
                 # verify that the automatic fields are sent to the target

--- a/tests/test_start_date.py
+++ b/tests/test_start_date.py
@@ -4,6 +4,8 @@ Test that the start_date configuration is respected
 
 from functools import reduce
 
+import os
+
 from dateutil.parser import parse
 
 from tap_tester import menagerie, runner
@@ -23,6 +25,26 @@ class StartDateTest(BaseTapTest):
       is greater than or equal to the start date
     """
 
+    def get_properties(self, original: bool = True):
+        return_value = {
+            'start_date': '2021-04-01T00:00:00Z',
+            'shop': 'talenddatawearhouse',
+            'date_window_size': 30,
+            'results_per_page': '50'
+        }
+
+        if original:
+            return return_value
+
+        return_value["start_date"] = '2021-04-21T00:00:00Z'
+        return return_value
+
+    @staticmethod
+    def get_credentials(original_credentials: bool = True):
+        return {
+            'api_key': os.getenv('TAP_SHOPIFY_API_KEY_2')
+        }
+
     @staticmethod
     def name():
         return "tap_tester_shopify_start_date_test"
@@ -38,10 +60,9 @@ class StartDateTest(BaseTapTest):
 
         # IF THERE ARE STREAMS THAT SHOULD NOT BE TESTED
         # REPLACE THE EMPTY SET BELOW WITH THOSE STREAMS
-        untested_streams = self.child_streams().union({'abandoned_checkouts', 'collects', 'metafields', 'transactions', 'order_refunds'})
+
         our_catalogs = [catalog for catalog in found_catalogs if
-                        catalog.get('tap_stream_id') in incremental_streams.difference(
-                            untested_streams)]
+                        catalog.get('tap_stream_id') in incremental_streams]
         self.select_all_streams_and_fields(conn_id, our_catalogs, select_all_fields=True)
 
         # Run a sync job using orchestrator
@@ -77,8 +98,7 @@ class StartDateTest(BaseTapTest):
         # Select all streams and all fields within streams
         found_catalogs = menagerie.get_catalogs(conn_id)
         our_catalogs = [catalog for catalog in found_catalogs if
-                        catalog.get('tap_stream_id') in incremental_streams.difference(
-                            untested_streams)]
+                        catalog.get('tap_stream_id') in incremental_streams]
         self.select_all_streams_and_fields(conn_id, our_catalogs, select_all_fields=True)
 
         # Run a sync job using orchestrator
@@ -91,7 +111,7 @@ class StartDateTest(BaseTapTest):
         self.assertGreater(second_total_records, 0)
         self.assertLess(second_total_records, first_total_records)
 
-        for stream in incremental_streams.difference(untested_streams):
+        for stream in incremental_streams:
             with self.subTest(stream=stream):
 
                 # verify that each stream has less records than the first connection sync

--- a/tests/test_start_date.py
+++ b/tests/test_start_date.py
@@ -43,7 +43,7 @@ class StartDateTest(BaseTapTest):
     @staticmethod
     def get_credentials(original_credentials: bool = True):
         return {
-            'api_key': os.getenv('TAP_SHOPIFY_API_KEY_2')
+            'api_key': os.getenv('TAP_SHOPIFY_API_KEY_TALENDDATAWEARHOUSE')
         }
 
     @staticmethod

--- a/tests/test_start_date.py
+++ b/tests/test_start_date.py
@@ -30,6 +30,7 @@ class StartDateTest(BaseTapTest):
             'start_date': '2021-04-01T00:00:00Z',
             'shop': 'talenddatawearhouse',
             'date_window_size': 30,
+            # BUG: https://jira.talendforge.org/browse/TDL-13180
             'results_per_page': '50'
         }
 


### PR DESCRIPTION
# Description of change
This PR 
- removes the "untestable streams" list from all tests.
- makes the test match the tap and expect the default page size to be 175, not 250
- adds bookmarking to `order_refunds`
- adds bookmarking to `transactions`
- adds shopify error handling to `transactions`
  - The tests would fail with unhandled `429`s
- adds pagination to `transactions`

The only test expectation that changed is this line in the automatic_fields test
``` diff
- self.expected_foreign_keys().get(stream, set())
```

# QA steps
 - [x] automated tests passing
 - [x] manual qa steps passing (list below)
   - All tests pass locally 
 
# Risks
- Low

# Rollback steps
 - revert this branch
