### PR TITLE
Note tested python versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.3.2
+  * Add `python_requires` to `setup.py` [#101](https://github.com/singer-io/tap-shopify/pull/101)
+    * We've tested the tap on `python 3.5.2` and `python 3.8.0`
+
 ## 1.3.1
   * Canonicalize `Timestamp` to `timestamp` on `Transactions.receipt` [#98](https://github.com/singer-io/tap-shopify/pull/98)
 

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ setup(
     author="Stitch",
     url="http://github.com/singer-io/tap-shopify",
     classifiers=["Programming Language :: Python :: 3 :: Only"],
+    python_requires='>=3.5.2',
     py_modules=["tap_shopify"],
     install_requires=[
         "ShopifyAPI==8.4.1",

--- a/tests/test_start_date.py
+++ b/tests/test_start_date.py
@@ -88,10 +88,7 @@ class StartDateTest(BaseTapTest):
             # REMOVE CODE TO FIND A START DATE AND ENTER ONE MANUALLY
             raise ValueError
 
-        largest_bookmark = reduce(lambda a, b: a if a > b else b, bookmark_dates)
-        self.start_date = self.local_to_utc(largest_bookmark) \
-                              .replace(hour=0, minute=0, second=0) \
-                              .strftime(self.START_DATE_FORMAT)
+        self.start_date = self.get_properties(original=False)["start_date"]
 
         # create a new connection with the new start_date
         conn_id = self.create_connection(original_properties=False)


### PR DESCRIPTION
# Description of change
This PR flags python versions we've ran the tap against. 

This change was motivated by python 3.5 reaching end of life last year, [see more details](https://www.python.org/downloads/release/python-352/)

# QA steps
 - [x] automated tests passing
 - [x] manual qa steps passing (list below)
    - [x] Ran tap locally
 
# Risks
- Low 

# Rollback steps
 - revert this branch
