### PR TITLE
Canonicalize `build`

### DIFF
--- a/tap_shopify/streams/transactions.py
+++ b/tap_shopify/streams/transactions.py
@@ -105,7 +105,7 @@ class Transactions(Stream):
             transaction_dict = transaction.to_dict()
             replication_value = strptime_to_utc(transaction_dict[self.replication_key])
             if replication_value >= bookmark:
-                for field_name in ['token', 'version', 'ack', 'timestamp']:
+                for field_name in ['token', 'version', 'ack', 'timestamp', 'build']:
                     canonicalize(transaction_dict, field_name)
                 yield transaction_dict
 


### PR DESCRIPTION
# Description of change
Add `build` to list of fields we canonicalize

# QA steps
 - [ ] automated tests passing
 - [x] manual qa steps passing (list below)
    - [x] Ran the tap without the change, saw `"Build"` key. Ran the tap with the change and ensured the record only differs in that `"Build"` key
 
# Risks
- Low

# Rollback steps
 - revert this branch
