### PR TITLE
Bump to v1.3.3, update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.3.3.
+  * Add `build` to the list of fields we canonicalize for the Transactions stream [#103](https://github.com/singer-io/tap-shopify/pull/103)
+
 ## 1.3.2
   * Add `python_requires` to `setup.py` [#101](https://github.com/singer-io/tap-shopify/pull/101)
     * We've tested the tap on `python 3.5.2` and `python 3.8.0`

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-shopify",
-    version="1.3.2",
+    version="1.3.3",
     description="Singer.io tap for extracting Shopify data",
     author="Stitch",
     url="http://github.com/singer-io/tap-shopify",


### PR DESCRIPTION
# Description of change
Version bump for #103 

## 1.3.3.
  * Add `build` to the list of fields we canonicalize for the Transactions stream [#103](https://github.com/singer-io/tap-shopify/pull/103)

# QA steps
 - [x] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks
- See #103 
# Rollback steps
 - revert this branch
