### PR TITLE
Add status field to products stream

### DIFF
--- a/tap_shopify/schemas/products.json
+++ b/tap_shopify/schemas/products.json
@@ -1,5 +1,11 @@
 {
   "properties": {
+    "status": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "published_at": {
       "type": [
         "null",


### PR DESCRIPTION
# Description of change
Adding status field to Products stream as specified in https://shopify.dev/docs/admin-api/rest/reference/products/product#index-2021-04

# QA steps
 - [X] automated tests passing
 - [X] manual qa steps passing (list below)
   `tap-shopify --discover -c ./config.json > catalog.json` > status present in JSON File
   `tap-shopify -c config.json --catalog catalog.json` > status present in tap output
  
# Risks

# Rollback steps
 - revert this branch
