### PR TITLE
URGENT Crash Fix: Fixed crash caused by Facebook Beta Shopify Connector

### DIFF
--- a/tap_shopify/streams/transactions.py
+++ b/tap_shopify/streams/transactions.py
@@ -23,29 +23,34 @@ TRANSACTIONS_RESULTS_PER_PAGE = 100
 # their values are not equal
 def canonicalize(transaction_dict, field_name):
     field_name_upper = field_name.capitalize()
-    value_lower = transaction_dict.get('receipt', {}).get(field_name)
-    value_upper = transaction_dict.get('receipt', {}).get(field_name_upper)
-    if value_lower and value_upper:
-        if value_lower == value_upper:
-            LOGGER.info((
-                "Transaction (id=%d) contains a receipt "
-                "that has `%s` and `%s` keys with the same "
-                "value. Removing the `%s` key."),
+    # Not all Shopify transactions have receipts. Facebook has been shown
+    # to push a null receipt through the transaction
+    receipt = transaction_dict.get('receipt', {})
+    if receipt:
+        value_lower = receipt.get(field_name)
+        value_upper = receipt.get(field_name_upper)
+        if value_lower and value_upper:
+            if value_lower == value_upper:
+                LOGGER.info((
+                    "Transaction (id=%d) contains a receipt "
+                    "that has `%s` and `%s` keys with the same "
+                    "value. Removing the `%s` key."),
+                            transaction_dict['id'],
+                            field_name,
+                            field_name_upper,
+                            field_name_upper)
+                transaction_dict['receipt'].pop(field_name_upper)
+            else:
+                raise ValueError((
+                    "Found Transaction (id={}) with a receipt that has "
+                    "`{}` and `{}` keys with the different "
+                    "values. Contact Shopify/PayPal support.").format(
                         transaction_dict['id'],
-                        field_name,
                         field_name_upper,
-                        field_name_upper)
-            transaction_dict['receipt'].pop(field_name_upper)
-        else:
-            raise ValueError((
-                "Found Transaction (id={}) with a receipt that has "
-                "`{}` and `{}` keys with the different "
-                "values. Contact Shopify/PayPal support.").format(
-                    transaction_dict['id'],
-                    field_name_upper,
-                    field_name))
-    elif value_upper:
-        transaction_dict["receipt"][field_name] = transaction_dict['receipt'].pop(field_name_upper)
+                        field_name))
+        elif value_upper:
+            # pylint: disable=line-too-long
+            transaction_dict["receipt"][field_name] = transaction_dict['receipt'].pop(field_name_upper)
 
 
 class Transactions(Stream):

--- a/tests/unittests/test_transaction_canonicalize.py
+++ b/tests/unittests/test_transaction_canonicalize.py
@@ -22,6 +22,12 @@ class TestTransactionCanonicalize(unittest.TestCase):
         canonicalize(record, "foo")
         self.assertEqual(record, expected_record)
 
+    def test_null_receipt_record(self):
+        record = {"receipt": None}
+        expected_record = {"receipt": None}
+        canonicalize(record, "foo")
+        self.assertEqual(record, expected_record)
+
     def test_removes_uppercase_if_both_exist_and_are_equal(self):
         record = {"receipt": {"Foo": "bar", "foo": "bar"}, "id": 2}
         expected_record = {"receipt": {"foo": "bar"}, "id": 2}


### PR DESCRIPTION
We are part of Facebook/Instagram's beta program for their connectors into Shopify. On Friday, part of our Facebook/Shopify  integration was upgraded to their latest codebase. In this codebase, Facebook began sending `null` receipt data for all Shopify `transaction` objects. Note they weren't excluding the `receipt` key, but explicitly setting it to `null`

```
...
'receipt': null
...
```

This behavior led to a crash inside the `canonicalize` method in the Stitch Shopify connector, which has led our entire Shopify connector to be down since late Friday night in crash loop.

# Description of change
The change here simply safely handles the case where the receipt could be `null`. In the past, the codebase assumed at a minimum that an empty (`{}`) dictionary would exist for this key, or that the `receipt` key wouldn't exist at all, and was crashing when trying to access a key within the receipt when the receipt was `null`. Now, there will be no operations when the receipt is `null`.

I have added a test case explicitly showing the crash. If you run the test without my patch, you will see the crash. Running the test with my patch yields no crash.

# QA steps
 - [x] automated tests passing
 
# Risks
Minimum. Our entire reporting arm is down in our business until this is resolved, so urgency is extremely high for me to get this deployed today.

# Rollback steps
 - revert this branch



## Test
I created a test to demonstrate the issue. When running the test without my patch, it causes a crash. Running with my patch passes as expected.

```python
    def test_null_receipt_record(self):
        record = {"receipt": None}
        expected_record = {"receipt": None}
        canonicalize(record, "foo")
        self.assertEqual(record, expected_record)
```

### Test without my patch:
```
nosetests tests/unittests
.EINFO Transaction (id=2) contains a receipt that has `foo` and `Foo` keys with the same value. Removing the `Foo` key.
....
======================================================================
ERROR: test_null_receipt_record (test_transaction_canonicalize.TestTransactionCanonicalize)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/kevin/git/tap-shopify/tests/unittests/test_transaction_canonicalize.py", line 28, in test_null_receipt_record
    canonicalize(record, "foo")
  File "/Users/kevin/git/tap-shopify/tap_shopify/streams/transactions.py", line 26, in canonicalize
    value_lower = transaction_dict.get('receipt', {}).get(field_name)
AttributeError: 'NoneType' object has no attribute 'get'

----------------------------------------------------------------------
Ran 6 tests in 0.322s

FAILED (errors=1)
```


### Test with my patch:

```
nosetests tests/unittests
..INFO Transaction (id=2) contains a receipt that has `foo` and `Foo` keys with the same value. Removing the `Foo` key.
....
----------------------------------------------------------------------
Ran 6 tests in 0.298s

OK
```

