### PR TITLE
TDL-15172: Discover mode should check token

### DIFF
--- a/tap_shopify/__init__.py
+++ b/tap_shopify/__init__.py
@@ -24,6 +24,7 @@ def initialize_shopify_client():
     version = '2021-04'
     session = shopify.Session(shop, version, api_key)
     shopify.ShopifyResource.activate_session(session)
+    # Shop.current() makes a call for shop details with provided shop and api_key
     return shopify.Shop.current().attributes
 
 def get_abs_path(path):

--- a/tap_shopify/__init__.py
+++ b/tap_shopify/__init__.py
@@ -24,6 +24,7 @@ def initialize_shopify_client():
     version = '2021-04'
     session = shopify.Session(shop, version, api_key)
     shopify.ShopifyResource.activate_session(session)
+    return shopify.Shop.current().attributes
 
 def get_abs_path(path):
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), path)
@@ -70,6 +71,8 @@ def load_schema_references():
     return refs
 
 def discover():
+    initialize_shopify_client() # Checking token in discover mode
+
     raw_schemas = load_schemas()
     streams = []
 
@@ -141,32 +144,15 @@ def sync():
         Context.state['bookmarks']['currently_sync_stream'] = stream_id
 
         with Transformer() as transformer:
-            try:
-                for rec in stream.sync():
-                    extraction_time = singer.utils.now()
-                    record_schema = catalog_entry['schema']
-                    record_metadata = metadata.to_map(catalog_entry['metadata'])
-                    rec = transformer.transform(rec, record_schema, record_metadata)
-                    singer.write_record(stream_id,
-                                        rec,
-                                        time_extracted=extraction_time)
-                    Context.counts[stream_id] += 1
-            except pyactiveresource.connection.ResourceNotFound as exc:
-                raise ShopifyError(exc, 'Ensure shop is entered correctly') from exc
-            except pyactiveresource.connection.UnauthorizedAccess as exc:
-                raise ShopifyError(exc, 'Invalid access token - Re-authorize the connection') \
-                    from exc
-            except pyactiveresource.connection.ConnectionError as exc:
-                msg = ''
-                try:
-                    body_json = exc.response.body.decode()
-                    body = json.loads(body_json)
-                    msg = body.get('errors')
-                finally:
-                    raise ShopifyError(exc, msg) from exc
-            except Exception as exc:
-                raise ShopifyError(exc) from exc
-
+            for rec in stream.sync():
+                extraction_time = singer.utils.now()
+                record_schema = catalog_entry['schema']
+                record_metadata = metadata.to_map(catalog_entry['metadata'])
+                rec = transformer.transform(rec, record_schema, record_metadata)
+                singer.write_record(stream_id,
+                                    rec,
+                                    time_extracted=extraction_time)
+                Context.counts[stream_id] += 1
 
         Context.state['bookmarks'].pop('currently_sync_stream')
         singer.write_state(Context.state)
@@ -178,24 +164,41 @@ def sync():
 
 @utils.handle_top_exception(LOGGER)
 def main():
-    # Parse command line arguments
-    args = utils.parse_args(REQUIRED_CONFIG_KEYS)
-
-    # If discover flag was passed, run discovery mode and dump output to stdout
-    if args.discover:
-        catalog = discover()
-        print(json.dumps(catalog, indent=2))
-    # Otherwise run in sync mode
-    else:
-        Context.tap_start = utils.now()
-        if args.catalog:
-            Context.catalog = args.catalog.to_dict()
-        else:
-            Context.catalog = discover()
+    try:
+        # Parse command line arguments
+        args = utils.parse_args(REQUIRED_CONFIG_KEYS)
 
         Context.config = args.config
         Context.state = args.state
-        sync()
+
+        # If discover flag was passed, run discovery mode and dump output to stdout
+        if args.discover:
+            catalog = discover()
+            print(json.dumps(catalog, indent=2))
+        # Otherwise run in sync mode
+        else:
+            Context.tap_start = utils.now()
+            if args.catalog:
+                Context.catalog = args.catalog.to_dict()
+            else:
+                Context.catalog = discover()
+
+            sync()
+    except pyactiveresource.connection.ResourceNotFound as exc:
+        raise ShopifyError(exc, 'Ensure shop is entered correctly') from exc
+    except pyactiveresource.connection.UnauthorizedAccess as exc:
+        raise ShopifyError(exc, 'Invalid access token - Re-authorize the connection') \
+            from exc
+    except pyactiveresource.connection.ConnectionError as exc:
+        msg = ''
+        try:
+            body_json = exc.response.body.decode()
+            body = json.loads(body_json)
+            msg = body.get('errors')
+        finally:
+            raise ShopifyError(exc, msg) from exc
+    except Exception as exc:
+        raise ShopifyError(exc) from exc
 
 if __name__ == "__main__":
     main()

--- a/tests/unittests/test_token_check_in_discover.py
+++ b/tests/unittests/test_token_check_in_discover.py
@@ -1,0 +1,84 @@
+from unittest import mock
+
+import pyactiveresource
+import tap_shopify
+import unittest
+
+# Mock args
+class Args():
+    def __init__(self):
+        self.discover = True
+        self.catalog = False
+        self.config = {'api_key': 'test', 'shop': 'shop'}
+        self.state = False
+
+def resource_not_found_raiser():
+    raise pyactiveresource.connection.ResourceNotFound
+
+def unauthorized_access_raiser():
+    raise pyactiveresource.connection.UnauthorizedAccess
+
+def connection_error_raiser():
+    raise pyactiveresource.connection.ConnectionError
+
+@mock.patch('tap_shopify.utils.parse_args')
+@mock.patch('tap_shopify.discover', side_effect=tap_shopify.discover)
+@mock.patch("builtins.print")
+class TestTokenInDiscoverMode(unittest.TestCase):
+
+    @mock.patch('tap_shopify.initialize_shopify_client', side_effect=resource_not_found_raiser)
+    def test_resource_not_found(self, mocked_client, mocked_print, mocked_discover, mocked_args):
+        '''
+            Verify exception is raised for ResourceNotFound with proper error message and
+            test that discover mode is called 
+        '''
+        mocked_args.return_value = Args()
+        try:
+            tap_shopify.main()
+        except tap_shopify.ShopifyError as e:
+            self.assertEqual(str(e), 'ResourceNotFound\nEnsure shop is entered correctly')
+            self.assertEqual(mocked_discover.call_count, 1)
+            self.assertEqual(mocked_client.call_count, 1)
+            self.assertEqual(mocked_print.call_count, 0)
+
+    @mock.patch('tap_shopify.initialize_shopify_client', side_effect=unauthorized_access_raiser)
+    def test_unauthorized_access(self, mocked_client, mocked_print, mocked_discover, mocked_args):
+        '''
+            Verify exception is raised for UnauthorizedAccess with proper error message and
+            test that discover mode is called 
+        '''
+        mocked_args.return_value = Args()
+        try:
+            tap_shopify.main()
+        except tap_shopify.ShopifyError as e:
+            self.assertEqual(str(e), 'UnauthorizedAccess\nInvalid access token - Re-authorize the connection')
+            self.assertEqual(mocked_discover.call_count, 1)
+            self.assertEqual(mocked_client.call_count, 1)
+            self.assertEqual(mocked_print.call_count, 0)
+
+    @mock.patch('tap_shopify.initialize_shopify_client', side_effect=connection_error_raiser)
+    def test_connection_error(self, mocked_client, mocked_print, mocked_discover, mocked_args):
+        '''
+            Verify exception is raised for ConnectionError with proper error message and
+            test that discover mode is called 
+        '''
+        mocked_args.return_value = Args()
+        try:
+            tap_shopify.main()
+        except tap_shopify.ShopifyError as e:
+            self.assertEqual(str(e), 'ConnectionError\n')
+            self.assertEqual(mocked_discover.call_count, 1)
+            self.assertEqual(mocked_client.call_count, 1)
+            self.assertEqual(mocked_print.call_count, 0)
+
+    @mock.patch('tap_shopify.initialize_shopify_client')
+    def test_no_error(self, mocked_client, mocked_print, mocked_discover, mocked_args):
+        '''
+            Verify that if no error during discover then print should be called once for
+            writing catalog
+        '''
+        mocked_args.return_value = Args()
+        tap_shopify.main()
+        self.assertEqual(mocked_discover.call_count, 1)
+        self.assertEqual(mocked_client.call_count, 1)
+        self.assertEqual(mocked_print.call_count, 1)


### PR DESCRIPTION
# Description of change
TDL-15172: Discover mode should check token
- Added one shop info-related call into initialize_shopify_client() and called it from discover mode.
- Moved try-except from sync mode call to main() function as discover cal also throw an exception in an invalid configuration.

# QA steps
 - [x] automated tests passing
 - [x] manual qa steps passing (list below)
   - Verified that if the wrong _shop name_ is provided then the ResourceNotFound related exception is raised.
   - Verified that if the wrong _API key_ is provided then UnauthorizedAccess related exception is raised.
 
# Risks

# Rollback steps
 - revert this branch
