### PR TITLE
V1.5.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 jobs:
   build:
     docker:
-      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:ubuntu-1804-stitch-tap-tester
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 jobs:
   build:
     docker:
-      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:ubuntu-1804-stitch-tap-tester
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester
     steps:
       - checkout
       - run:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.5.0
+  * Adds `events` stream [#127](https://github.com/singer-io/tap-shopify/pull/127)
+
 ## 1.4.0
   * Add shop info in record [#115](https://github.com/singer-io/tap-shopify/pull/115)
   * Add inventory item data [#118] (https://github.com/singer-io/tap-shopify/pull/118)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-shopify",
-    version="1.4.0",
+    version="1.5.0",
     description="Singer.io tap for extracting Shopify data",
     author="Stitch",
     url="http://github.com/singer-io/tap-shopify",

--- a/tap_shopify/streams/base.py
+++ b/tap_shopify/streams/base.py
@@ -153,7 +153,8 @@ class Stream():
                 query_params = {
                     "since_id": since_id,
                     "updated_at_min": updated_at_min,
-                    "created_at_min": updated_at_min, # For events, which requires the `created_at_min` query param for filtering
+                    "created_at_min": updated_at_min, # For events, which requires the
+                                                      #`created_at_min` query param for filtering
                     "updated_at_max": updated_at_max,
                     "created_at_max": updated_at_max,
                     "limit": self.results_per_page,

--- a/tap_shopify/streams/base.py
+++ b/tap_shopify/streams/base.py
@@ -126,6 +126,15 @@ class Stream():
     def call_api(self, query_params):
         return self.replication_object.find(**query_params)
 
+    def get_query_params(self, since_id, status_key, updated_at_min, updated_at_max):
+        return {
+            "since_id": since_id,
+            "updated_at_min": updated_at_min,
+            "updated_at_max": updated_at_max,
+            "limit": self.results_per_page,
+            status_key: "any"
+        }
+
     def get_objects(self):
         updated_at_min = self.get_bookmark()
 
@@ -150,16 +159,10 @@ class Stream():
                 updated_at_max = stop_time
             while True:
                 status_key = self.status_key or "status"
-                query_params = {
-                    "since_id": since_id,
-                    "updated_at_min": updated_at_min,
-                    "created_at_min": updated_at_min, # For events, which requires the
-                                                      #`created_at_min` query param for filtering
-                    "updated_at_max": updated_at_max,
-                    "created_at_max": updated_at_max,
-                    "limit": self.results_per_page,
-                    status_key: "any"
-                }
+                query_params = self.get_query_params(since_id,
+                                                     status_key,
+                                                     updated_at_min,
+                                                     updated_at_max)
 
                 with metrics.http_request_timer(self.name):
                     objects = self.call_api(query_params)

--- a/tap_shopify/streams/events.py
+++ b/tap_shopify/streams/events.py
@@ -9,11 +9,11 @@ class Events(Stream):
     replication_object = shopify.Event
     replication_key = "created_at"
 
-    def get_query_params(self, since_id, status_key, created_at_min, created_at_max):
+    def get_query_params(self, since_id, status_key, updated_at_min, updated_at_max):
         return {
             "since_id": since_id,
-            "created_at_min": created_at_min,
-            "created_at_max": created_at_max,
+            "created_at_min": updated_at_min,
+            "created_at_max": updated_at_max,
             "limit": self.results_per_page,
             status_key: "any"
         }

--- a/tap_shopify/streams/events.py
+++ b/tap_shopify/streams/events.py
@@ -9,4 +9,13 @@ class Events(Stream):
     replication_object = shopify.Event
     replication_key = "created_at"
 
+    def get_query_params(self, since_id, status_key, created_at_min, created_at_max):
+        return {
+            "since_id": since_id,
+            "created_at_min": created_at_min,
+            "created_at_max": created_at_max,
+            "limit": self.results_per_page,
+            status_key: "any"
+        }
+
 Context.stream_objects['events'] = Events

--- a/tests/base.py
+++ b/tests/base.py
@@ -297,5 +297,5 @@ class BaseTapTest(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.start_date = self.get_properties().get("start_date")
-        self.store_1_streams = {'custom_collections', 'orders', 'products', 'customers', 'locations', 'inventory_levels', 'inventory_items'}
-        self.store_2_streams = {'abandoned_checkouts', 'collects', 'metafields', 'transactions', 'order_refunds', 'products', 'locations', 'inventory_levels', 'inventory_items'}
+        self.store_1_streams = {'custom_collections', 'orders', 'products', 'customers', 'locations', 'inventory_levels', 'inventory_items', 'events'}
+        self.store_2_streams = {'abandoned_checkouts', 'collects', 'metafields', 'transactions', 'order_refunds', 'products', 'locations', 'inventory_levels', 'inventory_items', 'events'}

--- a/tests/base.py
+++ b/tests/base.py
@@ -118,7 +118,13 @@ class BaseTapTest(unittest.TestCase):
                 self.REPLICATION_KEYS: {"updated_at"},
                 self.PRIMARY_KEYS: {"location_id", "inventory_item_id"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
-                self.API_LIMIT: self.DEFAULT_RESULTS_PER_PAGE}
+                self.API_LIMIT: self.DEFAULT_RESULTS_PER_PAGE},
+            "events": {
+                self.REPLICATION_KEYS: {"created_at"},
+                self.PRIMARY_KEYS: {"id"},
+                self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.API_LIMIT: 50
+            }
         }
 
     def expected_streams(self):


### PR DESCRIPTION
# Description of change
This PR is the version bump for #127.

It also adds the `Events` stream added in #127 to the integration test suite.

### Some test failures and how they were addressed
* Integration tests
    * We were seeing assertions fail because the API was returning less data than expected
        * `get_query_params()` was created in order to allow `Events` to use the `"created_at_min"` and `"created_at_max"` params
        * In every other stream, those parameters caused the record count discrepancy
   * No tests were being run for the `Events` stream
       * This PR adds them to the `store_*_streams` allow list variables
* Pylint
    * Complained that the child class `Events` used different variable names in `get_query_params()`
        * So I kept them the same

# QA steps
 - [x] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks
- Low

# Rollback steps
 - revert this branch
