### PR TITLE
TDL-16648: Implement request timeouts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,17 @@ jobs:
           command: |
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             stitch-validate-json tap_shopify/schemas/*.json
+      - run:
+          name: 'Unit Tests'
+          command: |
+            source /usr/local/share/virtualenvs/tap-shopify/bin/activate
+            pip install nose coverage
+            nosetests --with-coverage --cover-erase --cover-package=tap_shopify --cover-html-dir=htmlcov tests/unittests
+            coverage html
+      - store_test_results:
+          path: test_output/report.xml
+      - store_artifacts:
+          path: htmlcov
       - add_ssh_keys
       - run:
           name: 'Integration Tests'

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ This tap:
     {
         "start_date": "2010-01-01",
         "api_key": "<Shopify API Key>",
-        "shop": "test_shop"
+        "shop": "test_shop",
+        "request_timeout": 300
     }
     ```
 
@@ -47,6 +48,8 @@ This tap:
    The `api_key` is the API key for your Shopify shop generated via an OAuth flow.
 
    The `shop` is your Shopify shop which will be the value `test_shop` in the string `https://test_shop.myshopify.com`
+
+    The `request_timeout` is the timeout for the requests. Default: 300 seconds
 
 4. Run the Tap in Discovery Mode
 

--- a/tap_shopify/__init__.py
+++ b/tap_shopify/__init__.py
@@ -14,7 +14,7 @@ from singer import metadata
 from singer import Transformer
 from tap_shopify.context import Context
 from tap_shopify.exceptions import ShopifyError
-from tap_shopify.streams.base import shopify_error_handling, REQUEST_TIMEOUT
+from tap_shopify.streams.base import shopify_error_handling, get_request_timeout
 import tap_shopify.streams # Load stream objects into Context
 
 REQUIRED_CONFIG_KEYS = ["shop", "api_key"]
@@ -29,14 +29,8 @@ def initialize_shopify_client():
     session = shopify.Session(shop, version, api_key)
     shopify.ShopifyResource.activate_session(session)
 
-    request_timeout = REQUEST_TIMEOUT # set default timeout
-    timeout_from_config = Context.config.get('request_timeout')
-    # updated the timeout value if timeout is passed in config and not from 0, "0", ""
-    if timeout_from_config and float(timeout_from_config):
-        # update the request timeout for the requests
-        request_timeout = float(timeout_from_config)
-
-    shopify.Shop.set_timeout(request_timeout)
+    # set request timeout
+    shopify.Shop.set_timeout(get_request_timeout())
 
     # Shop.current() makes a call for shop details with provided shop and api_key
     return shopify.Shop.current().attributes

--- a/tap_shopify/streams/base.py
+++ b/tap_shopify/streams/base.py
@@ -71,7 +71,7 @@ def shopify_error_handling(fnc):
     @backoff.on_exception(backoff.expo, # timeout error raise by Shopify
                           pyactiveresource.connection.Error,
                           giveup=is_timeout_error(),
-                          max_tries=5,
+                          max_tries=MAX_RETRIES,
                           factor=2)
     @backoff.on_exception(backoff.expo,
                           (pyactiveresource.connection.ServerError,

--- a/tap_shopify/streams/base.py
+++ b/tap_shopify/streams/base.py
@@ -2,7 +2,7 @@ import datetime
 import functools
 import math
 import sys
-
+import socket
 import backoff
 import pyactiveresource
 import pyactiveresource.formats
@@ -69,7 +69,7 @@ def is_timeout_error():
 
 def shopify_error_handling(fnc):
     @backoff.on_exception(backoff.expo, # timeout error raise by Shopify
-                          pyactiveresource.connection.Error,
+                          (pyactiveresource.connection.Error, socket.timeout),
                           giveup=is_timeout_error(),
                           max_tries=MAX_RETRIES,
                           factor=2)

--- a/tap_shopify/streams/base.py
+++ b/tap_shopify/streams/base.py
@@ -25,6 +25,18 @@ DATE_WINDOW_SIZE = 1
 # We will retry a 500 error a maximum of 5 times before giving up
 MAX_RETRIES = 5
 
+# function to return request timeout
+def get_request_timeout():
+
+    request_timeout = REQUEST_TIMEOUT # set default timeout
+    timeout_from_config = Context.config.get('request_timeout')
+    # updated the timeout value if timeout is passed in config and not from 0, "0", ""
+    if timeout_from_config and float(timeout_from_config):
+        # update the request timeout for the requests
+        request_timeout = float(timeout_from_config)
+
+    return request_timeout
+
 def is_not_status_code_fn(status_code):
     def gen_fn(exc):
         if getattr(exc, 'code', None) and exc.code not in status_code:
@@ -113,12 +125,8 @@ class Stream():
     def __init__(self):
         self.results_per_page = Context.get_results_per_page(RESULTS_PER_PAGE)
 
-        self.request_timeout = REQUEST_TIMEOUT # set default timeout
-        timeout_from_config = Context.config.get('request_timeout')
-        # updated the timeout value if timeout is passed in config and not from 0, "0", ""
-        if timeout_from_config and float(timeout_from_config):
-            # update the request timeout for the requests
-            self.request_timeout = float(timeout_from_config)
+        # set request timeout
+        self.request_timeout = get_request_timeout()
 
     def get_bookmark(self):
         bookmark = (singer.get_bookmark(Context.state,

--- a/tap_shopify/streams/base.py
+++ b/tap_shopify/streams/base.py
@@ -68,8 +68,8 @@ def is_timeout_error():
     return gen_fn
 
 def shopify_error_handling(fnc):
-    @backoff.on_exception(backoff.expo,
-                          pyactiveresource.connection.Error, # contains timeout error raise by Shopify
+    @backoff.on_exception(backoff.expo, # timeout error raise by Shopify
+                          pyactiveresource.connection.Error,
                           giveup=is_timeout_error(),
                           max_tries=5,
                           factor=2)

--- a/tap_shopify/streams/base.py
+++ b/tap_shopify/streams/base.py
@@ -66,13 +66,13 @@ def retry_after_wait_gen(**kwargs):
     yield math.floor(float(sleep_time_str))
 
 # boolean function to check if the error is 'timeout' error or not
-def is_timeout_error(e):
+def is_timeout_error(error_raised):
     """
         This function checks whether the error contains 'timed out' substring and return boolean
         values accordingly, to decide whether to backoff or not.
     """
     # retry if the error string contains 'timed out'
-    if str(e).__contains__('timed out'):
+    if str(error_raised).__contains__('timed out'):
         return False
     return True
 

--- a/tap_shopify/streams/base.py
+++ b/tap_shopify/streams/base.py
@@ -66,23 +66,20 @@ def retry_after_wait_gen(**kwargs):
     yield math.floor(float(sleep_time_str))
 
 # boolean function to check if the error is 'timeout' error or not
-def is_timeout_error():
+def is_timeout_error(e):
     """
         This function checks whether the error contains 'timed out' substring and return boolean
         values accordingly, to decide whether to backoff or not.
     """
-    def gen_fn(exc):
-        if str(exc).__contains__('timed out'):
-            # retry if the error string contains 'timed out'
-            return False
-        return True
-
-    return gen_fn
+    # retry if the error string contains 'timed out'
+    if str(e).__contains__('timed out'):
+        return False
+    return True
 
 def shopify_error_handling(fnc):
     @backoff.on_exception(backoff.expo, # timeout error raise by Shopify
                           (pyactiveresource.connection.Error, socket.timeout),
-                          giveup=is_timeout_error(),
+                          giveup=is_timeout_error,
                           max_tries=MAX_RETRIES,
                           factor=2)
     @backoff.on_exception(backoff.expo,

--- a/tap_shopify/streams/inventory_items.py
+++ b/tap_shopify/streams/inventory_items.py
@@ -14,6 +14,8 @@ class InventoryItems(Stream):
 
     @shopify_error_handling
     def get_inventory_items(self, inventory_items_ids):
+        # set timeout
+        self.replication_object.set_timeout(self.request_timeout)
         return self.replication_object.find(
             ids=inventory_items_ids,
             limit=RESULTS_PER_PAGE)

--- a/tap_shopify/streams/inventory_levels.py
+++ b/tap_shopify/streams/inventory_levels.py
@@ -10,9 +10,12 @@ class InventoryLevels(Stream):
     replication_key = 'updated_at'
     key_properties = ['location_id', 'inventory_item_id']
     replication_object = shopify.InventoryLevel
+    # Added decorator over functions of shopify SDK
+    replication_object.find = shopify_error_handling(replication_object.find)
 
-    @shopify_error_handling
     def api_call_for_inventory_levels(self, parent_object_id, bookmark):
+        # set timeout
+        self.replication_object.set_timeout(self.request_timeout)
         return self.replication_object.find(
             updated_at_min = bookmark,
             limit = RESULTS_PER_PAGE,

--- a/tap_shopify/streams/locations.py
+++ b/tap_shopify/streams/locations.py
@@ -6,9 +6,12 @@ from tap_shopify.context import Context
 class Locations(Stream):
     name = 'locations'
     replication_object = shopify.Location
+    # Added decorator over functions of shopify SDK
+    replication_object.find = shopify_error_handling(replication_object.find)
 
-    @shopify_error_handling
     def get_locations_data(self):
+        # set timeout
+        self.replication_object.set_timeout(self.request_timeout)
         location_page = self.replication_object.find()
         yield from location_page
 

--- a/tap_shopify/streams/metafields.py
+++ b/tap_shopify/streams/metafields.py
@@ -42,7 +42,10 @@ class Metafields(Stream):
             for parent_object in selected_parent.get_objects():
                 since_id = 1
                 while True:
-                    metafields = get_metafields(parent_object, since_id, selected_parent.replication_object, self.request_timeout)
+                    metafields = get_metafields(parent_object,
+                                                since_id,
+                                                selected_parent.replication_object,
+                                                self.request_timeout)
                     for metafield in metafields:
                         if metafield.id < since_id:
                             raise OutOfOrderIdsError("metafield.id < since_id: {} < {}".format(

--- a/tap_shopify/streams/metafields.py
+++ b/tap_shopify/streams/metafields.py
@@ -16,7 +16,9 @@ def get_selected_parents():
             yield Context.stream_objects[parent_stream]()
 
 @shopify_error_handling
-def get_metafields(parent_object, since_id):
+def get_metafields(parent_object, since_id, timeout):
+    # set timeout
+    parent_object.set_timeout(timeout)
     # This call results in an HTTP request - the parent object never has a
     # cache of this data so we have to issue that request.
     return parent_object.metafields(
@@ -40,7 +42,7 @@ class Metafields(Stream):
             for parent_object in selected_parent.get_objects():
                 since_id = 1
                 while True:
-                    metafields = get_metafields(parent_object, since_id)
+                    metafields = get_metafields(parent_object, since_id, self.request_timeout)
                     for metafield in metafields:
                         if metafield.id < since_id:
                             raise OutOfOrderIdsError("metafield.id < since_id: {} < {}".format(

--- a/tap_shopify/streams/metafields.py
+++ b/tap_shopify/streams/metafields.py
@@ -16,9 +16,9 @@ def get_selected_parents():
             yield Context.stream_objects[parent_stream]()
 
 @shopify_error_handling
-def get_metafields(parent_object, since_id, timeout):
+def get_metafields(parent_object, since_id, parent_replication_object, timeout):
     # set timeout
-    parent_object.set_timeout(timeout)
+    parent_replication_object.set_timeout(timeout)
     # This call results in an HTTP request - the parent object never has a
     # cache of this data so we have to issue that request.
     return parent_object.metafields(
@@ -42,7 +42,7 @@ class Metafields(Stream):
             for parent_object in selected_parent.get_objects():
                 since_id = 1
                 while True:
-                    metafields = get_metafields(parent_object, since_id, self.request_timeout)
+                    metafields = get_metafields(parent_object, since_id, selected_parent.replication_object, self.request_timeout)
                     for metafield in metafields:
                         if metafield.id < since_id:
                             raise OutOfOrderIdsError("metafield.id < since_id: {} < {}".format(

--- a/tap_shopify/streams/order_refunds.py
+++ b/tap_shopify/streams/order_refunds.py
@@ -12,6 +12,8 @@ class OrderRefunds(Stream):
 
     @shopify_error_handling
     def get_refunds(self, parent_object, since_id):
+        # set timeout
+        self.replication_object.set_timeout(self.request_timeout)
         return self.replication_object.find(
             order_id=parent_object.id,
             limit=self.results_per_page,

--- a/tap_shopify/streams/transactions.py
+++ b/tap_shopify/streams/transactions.py
@@ -57,12 +57,15 @@ class Transactions(Stream):
     name = 'transactions'
     replication_key = 'created_at'
     replication_object = shopify.Transaction
+    # Added decorator over functions of shopify SDK
+    replication_object.find = shopify_error_handling(replication_object.find)
     # Transactions have no updated_at property. Therefore we have
     # nothing to set the `replication_method` member to.
     # https://help.shopify.com/en/api/reference/orders/transaction#properties
 
-    @shopify_error_handling
     def call_api_for_transactions(self, parent_object):
+        # set timeout
+        self.replication_object.set_timeout(self.request_timeout)
         return self.replication_object.find(
             limit=TRANSACTIONS_RESULTS_PER_PAGE,
             order_id=parent_object.id,

--- a/tests/unittests/test_timeout.py
+++ b/tests/unittests/test_timeout.py
@@ -1,0 +1,230 @@
+from unittest import mock
+import pyactiveresource
+import shopify
+from tap_shopify.context import Context
+from tap_shopify.streams.base import Stream
+from tap_shopify.streams.inventory_items import InventoryItems
+from tap_shopify.streams.inventory_levels import InventoryLevels
+from tap_shopify.streams.locations import Locations
+from tap_shopify.streams.order_refunds import OrderRefunds
+from tap_shopify.streams.transactions import Transactions
+from tap_shopify.streams.abandoned_checkouts import AbandonedCheckouts
+from tap_shopify.streams.metafields import Metafields
+from tap_shopify.streams.metafields import get_metafields
+import unittest
+
+class TestTimeoutValue(unittest.TestCase):
+    """
+        Verify the timeout value is set as expected by the tap
+    """
+
+    def test_timeout_value_not_passed_in_config(self):
+        # initialize config
+        Context.config = {
+            "start_date": "2021-01-01",
+            "api_key": "test_api_key",
+            "shop": "test_shop",
+            "results_per_page": 50
+        }
+
+        # initialize base class
+        stream = Stream()
+        # verify the timeout is set as expected
+        self.assertEquals(stream.request_timeout, 300)
+
+    def test_timeout_int_value_passed_in_config(self):
+        # initialize config
+        Context.config = {
+            "start_date": "2021-01-01",
+            "api_key": "test_api_key",
+            "shop": "test_shop",
+            "results_per_page": 50,
+            "request_timeout": 100
+        }
+
+        # initialize base class
+        stream = Stream()
+        # verify the timeout is set as expected
+        self.assertEquals(stream.request_timeout, 100)
+
+    def test_timeout_string_value_passed_in_config(self):
+        # initialize config
+        Context.config = {
+            "start_date": "2021-01-01",
+            "api_key": "test_api_key",
+            "shop": "test_shop",
+            "results_per_page": 50,
+            "request_timeout": "100"
+        }
+
+        # initialize base class
+        stream = Stream()
+        # verify the timeout is set as expected
+        self.assertEquals(stream.request_timeout, 100)
+
+    def test_timeout_empty_value_passed_in_config(self):
+        # initialize config
+        Context.config = {
+            "start_date": "2021-01-01",
+            "api_key": "test_api_key",
+            "shop": "test_shop",
+            "results_per_page": 50,
+            "request_timeout": ""
+        }
+
+        # initialize base class
+        stream = Stream()
+        # verify the timeout is set as expected
+        self.assertEquals(stream.request_timeout, 300)
+
+    def test_timeout_0_value_passed_in_config(self):
+        # initialize config
+        Context.config = {
+            "start_date": "2021-01-01",
+            "api_key": "test_api_key",
+            "shop": "test_shop",
+            "results_per_page": 50,
+            "request_timeout": 0.0
+        }
+
+        # initialize base class
+        stream = Stream()
+        # verify the timeout is set as expected
+        self.assertEquals(stream.request_timeout, 300)
+
+    def test_timeout_string_0_value_passed_in_config(self):
+        # initialize config
+        Context.config = {
+            "start_date": "2021-01-01",
+            "api_key": "test_api_key",
+            "shop": "test_shop",
+            "results_per_page": 50,
+            "request_timeout": "0.0"
+        }
+
+        # initialize base class
+        stream = Stream()
+        # verify the timeout is set as expected
+        self.assertEquals(stream.request_timeout, 300)
+
+class TestTimeoutBackoff(unittest.TestCase):
+    """
+        Verify the tap backoff for 5 times when timeout error occurs
+    """
+
+    @mock.patch("time.sleep")
+    @mock.patch("shopify.Checkout.find")
+    def test_AbandonedCheckouts_timeout_backoff(self, mocked_find, mocked_sleep):
+        # mock 'find' and raise timeout error
+        mocked_find.side_effect = pyactiveresource.connection.Error('urlopen error _ssl.c:1074: The handshake operation timed out')
+
+        # initialize 'AbandonedCheckouts' as it calls the function 'call_api' from the base class
+        abandoned_checkouts = AbandonedCheckouts()
+        try:
+            # function call
+            abandoned_checkouts.call_api({})
+        except pyactiveresource.connection.Error:
+            pass
+
+        # verify we backoff 5 times
+        self.assertEquals(mocked_find.call_count, 5)
+
+    @mock.patch("time.sleep")
+    @mock.patch("shopify.InventoryItem.find")
+    def test_InventoryItems_timeout_backoff(self, mocked_find, mocked_sleep):
+        # mock 'find' and raise timeout error
+        mocked_find.side_effect = pyactiveresource.connection.Error('urlopen error _ssl.c:1074: The handshake operation timed out')
+
+        # initialize class
+        inventory_items = InventoryItems()
+        try:
+            # function call
+            inventory_items.get_inventory_items([1, 2, 3])
+        except pyactiveresource.connection.Error:
+            pass
+
+        # verify we backoff 5 times
+        self.assertEquals(mocked_find.call_count, 5)
+
+    @mock.patch("time.sleep")
+    @mock.patch("pyactiveresource.activeresource.ActiveResource.find")
+    def test_InventoryLevels_timeout_backoff(self, mocked_find, mocked_sleep):
+        # mock 'find' and raise timeout error
+        mocked_find.side_effect = pyactiveresource.connection.Error('urlopen error _ssl.c:1074: The handshake operation timed out')
+
+        # initialize class
+        inventory_levels = InventoryLevels()
+        try:
+            # function call
+            inventory_levels.api_call_for_inventory_levels(1, 'test')
+        except pyactiveresource.connection.Error:
+            pass
+
+        # verify we backoff 5 times
+        self.assertEquals(mocked_find.call_count, 5)
+
+    @mock.patch("time.sleep")
+    @mock.patch("pyactiveresource.activeresource.ActiveResource.find")
+    def test_Locations_timeout_backoff(self, mocked_find, mocked_sleep):
+        # mock 'find' and raise timeout error
+        mocked_find.side_effect = pyactiveresource.connection.Error('urlopen error _ssl.c:1074: The handshake operation timed out')
+
+        # initialize class
+        locations = Locations()
+        try:
+            # function call
+            locations.replication_object.find()
+        except pyactiveresource.connection.Error:
+            pass
+
+        # verify we backoff 5 times
+        self.assertEquals(mocked_find.call_count, 5)
+
+    @mock.patch("time.sleep")
+    @mock.patch("shopify.Order.metafields")
+    def test_Metafields_timeout_backoff(self, mocked_find, mocked_sleep):
+        # mock 'find' and raise timeout error
+        mocked_find.side_effect = pyactiveresource.connection.Error('urlopen error _ssl.c:1074: The handshake operation timed out')
+
+        try:
+            # function call
+            get_metafields(shopify.Order, 1, 100)
+        except pyactiveresource.connection.Error:
+            pass
+
+        # verify we backoff 5 times
+        self.assertEquals(mocked_find.call_count, 5)
+
+    @mock.patch("time.sleep")
+    @mock.patch("shopify.Refund.find")
+    def test_OrderRefunds_timeout_backoff(self, mocked_find, mocked_sleep):
+        # mock 'find' and raise timeout error
+        mocked_find.side_effect = pyactiveresource.connection.Error('urlopen error _ssl.c:1074: The handshake operation timed out')
+
+        # initialize class
+        order_refunds = OrderRefunds()
+        try:
+            # function call
+            order_refunds.get_refunds(shopify.Product, 1)
+        except pyactiveresource.connection.Error:
+            pass
+
+        # verify we backoff 5 times
+        self.assertEquals(mocked_find.call_count, 5)
+
+    @mock.patch("time.sleep")
+    @mock.patch("pyactiveresource.activeresource.ActiveResource.find")
+    def test_Transactions_timeout_backoff(self, mocked_find, mocked_sleep):
+        # mock 'find' and raise timeout error
+        mocked_find.side_effect = pyactiveresource.connection.Error('urlopen error _ssl.c:1074: The handshake operation timed out')
+
+        # initialize class
+        locations = Transactions()
+        try:
+            # function call
+            locations.replication_object.find()
+        except pyactiveresource.connection.Error:
+            pass
+
+        # verify we backoff 5 times
+        self.assertEquals(mocked_find.call_count, 5)

--- a/tests/unittests/test_timeout.py
+++ b/tests/unittests/test_timeout.py
@@ -4,7 +4,7 @@ from unittest import mock
 import pyactiveresource
 import shopify
 from tap_shopify.context import Context
-from tap_shopify.streams.base import Stream
+from tap_shopify.streams.base import get_request_timeout
 from tap_shopify.streams.inventory_items import InventoryItems
 from tap_shopify.streams.inventory_levels import InventoryLevels
 from tap_shopify.streams.locations import Locations
@@ -21,6 +21,9 @@ class TestTimeoutValue(unittest.TestCase):
     """
 
     def test_timeout_value_not_passed_in_config(self):
+        """
+            Test case to verify that the default value is used when we do not pass request timeout value from config
+        """
         # initialize config
         Context.config = {
             "start_date": "2021-01-01",
@@ -30,11 +33,14 @@ class TestTimeoutValue(unittest.TestCase):
         }
 
         # initialize base class
-        stream = Stream()
+        timeout = get_request_timeout()
         # verify the timeout is set as expected
-        self.assertEquals(stream.request_timeout, 300)
+        self.assertEquals(timeout, 300)
 
     def test_timeout_int_value_passed_in_config(self):
+        """
+            Test case to verify that the value we passed on config is set as request timeout value
+        """
         # initialize config
         Context.config = {
             "start_date": "2021-01-01",
@@ -45,11 +51,14 @@ class TestTimeoutValue(unittest.TestCase):
         }
 
         # initialize base class
-        stream = Stream()
+        timeout = get_request_timeout()
         # verify the timeout is set as expected
-        self.assertEquals(stream.request_timeout, 100)
+        self.assertEquals(timeout, 100)
 
     def test_timeout_string_value_passed_in_config(self):
+        """
+            Test case to verify that the value we passed on config is set as request timeout value
+        """
         # initialize config
         Context.config = {
             "start_date": "2021-01-01",
@@ -60,11 +69,14 @@ class TestTimeoutValue(unittest.TestCase):
         }
 
         # initialize base class
-        stream = Stream()
+        timeout = get_request_timeout()
         # verify the timeout is set as expected
-        self.assertEquals(stream.request_timeout, 100)
+        self.assertEquals(timeout, 100)
 
     def test_timeout_empty_value_passed_in_config(self):
+        """
+            Test case to verify that the default value is used when pass empty request timeout value from config
+        """
         # initialize config
         Context.config = {
             "start_date": "2021-01-01",
@@ -75,11 +87,14 @@ class TestTimeoutValue(unittest.TestCase):
         }
 
         # initialize base class
-        stream = Stream()
+        timeout = get_request_timeout()
         # verify the timeout is set as expected
-        self.assertEquals(stream.request_timeout, 300)
+        self.assertEquals(timeout, 300)
 
     def test_timeout_0_value_passed_in_config(self):
+        """
+            Test case to verify that the default value is used when pass 0 as request timeout value from config
+        """
         # initialize config
         Context.config = {
             "start_date": "2021-01-01",
@@ -90,11 +105,14 @@ class TestTimeoutValue(unittest.TestCase):
         }
 
         # initialize base class
-        stream = Stream()
+        timeout = get_request_timeout()
         # verify the timeout is set as expected
-        self.assertEquals(stream.request_timeout, 300)
+        self.assertEquals(timeout, 300)
 
     def test_timeout_string_0_value_passed_in_config(self):
+        """
+            Test case to verify that the default value is used when pass string 0 as request timeout value from config
+        """
         # initialize config
         Context.config = {
             "start_date": "2021-01-01",
@@ -105,13 +123,16 @@ class TestTimeoutValue(unittest.TestCase):
         }
 
         # initialize base class
-        stream = Stream()
+        timeout = get_request_timeout()
         # verify the timeout is set as expected
-        self.assertEquals(stream.request_timeout, 300)
+        self.assertEquals(timeout, 300)
 
     @mock.patch("shopify.Shop.set_timeout")
     @mock.patch("shopify.Shop.current")
     def test_timeout_value_not_passed_in_config__initialize_shopify_client(self, mocked_current, mocked_set_timeout):
+        """
+            Test case to verify that the default value is used when we do not pass request timeout value from config
+        """
         # initialize config
         Context.config = {
             "start_date": "2021-01-01",
@@ -128,6 +149,9 @@ class TestTimeoutValue(unittest.TestCase):
     @mock.patch("shopify.Shop.set_timeout")
     @mock.patch("shopify.Shop.current")
     def test_timeout_int_value_passed_in_config__initialize_shopify_client(self, mocked_current, mocked_set_timeout):
+        """
+            Test case to verify that the value we passed on config is set as request timeout value
+        """
         # initialize config
         Context.config = {
             "start_date": "2021-01-01",
@@ -145,6 +169,9 @@ class TestTimeoutValue(unittest.TestCase):
     @mock.patch("shopify.Shop.set_timeout")
     @mock.patch("shopify.Shop.current")
     def test_timeout_string_value_passed_in_config__initialize_shopify_client(self, mocked_current, mocked_set_timeout):
+        """
+            Test case to verify that the value we passed on config is set as request timeout value
+        """
         # initialize config
         Context.config = {
             "start_date": "2021-01-01",
@@ -162,6 +189,9 @@ class TestTimeoutValue(unittest.TestCase):
     @mock.patch("shopify.Shop.set_timeout")
     @mock.patch("shopify.Shop.current")
     def test_timeout_empty_value_passed_in_config__initialize_shopify_client(self, mocked_current, mocked_set_timeout):
+        """
+            Test case to verify that the default value is used when pass empty request timeout value from config
+        """
         # initialize config
         Context.config = {
             "start_date": "2021-01-01",
@@ -179,6 +209,9 @@ class TestTimeoutValue(unittest.TestCase):
     @mock.patch("shopify.Shop.set_timeout")
     @mock.patch("shopify.Shop.current")
     def test_timeout_0_value_passed_in_config__initialize_shopify_client(self, mocked_current, mocked_set_timeout):
+        """
+            Test case to verify that the default value is used when pass 0 as request timeout value from config
+        """
         # initialize config
         Context.config = {
             "start_date": "2021-01-01",
@@ -196,6 +229,9 @@ class TestTimeoutValue(unittest.TestCase):
     @mock.patch("shopify.Shop.set_timeout")
     @mock.patch("shopify.Shop.current")
     def test_timeout_string_0_value_passed_in_config__initialize_shopify_client(self, mocked_current, mocked_set_timeout):
+        """
+            Test case to verify that the default value is used when pass string 0 as request timeout value from config
+        """
         # initialize config
         Context.config = {
             "start_date": "2021-01-01",
@@ -218,6 +254,9 @@ class TestTimeoutBackoff(unittest.TestCase):
     @mock.patch("time.sleep")
     @mock.patch("shopify.Checkout.find")
     def test_AbandonedCheckouts_pyactiveresource_error_timeout_backoff(self, mocked_find, mocked_sleep):
+        """
+            Test case to verify that we backoff for 5 times when 'pyactiveresource.connection.Error' error occurs
+        """
         # mock 'find' and raise timeout error
         mocked_find.side_effect = pyactiveresource.connection.Error('urlopen error _ssl.c:1074: The handshake operation timed out')
 
@@ -235,6 +274,9 @@ class TestTimeoutBackoff(unittest.TestCase):
     @mock.patch("time.sleep")
     @mock.patch("shopify.InventoryItem.find")
     def test_InventoryItems_pyactiveresource_error_timeout_backoff(self, mocked_find, mocked_sleep):
+        """
+            Test case to verify that we backoff for 5 times when 'pyactiveresource.connection.Error' error occurs
+        """
         # mock 'find' and raise timeout error
         mocked_find.side_effect = pyactiveresource.connection.Error('urlopen error _ssl.c:1074: The handshake operation timed out')
 
@@ -252,6 +294,9 @@ class TestTimeoutBackoff(unittest.TestCase):
     @mock.patch("time.sleep")
     @mock.patch("pyactiveresource.activeresource.ActiveResource.find")
     def test_InventoryLevels_pyactiveresource_error_timeout_backoff(self, mocked_find, mocked_sleep):
+        """
+            Test case to verify that we backoff for 5 times when 'pyactiveresource.connection.Error' error occurs
+        """
         # mock 'find' and raise timeout error
         mocked_find.side_effect = pyactiveresource.connection.Error('urlopen error _ssl.c:1074: The handshake operation timed out')
 
@@ -269,6 +314,9 @@ class TestTimeoutBackoff(unittest.TestCase):
     @mock.patch("time.sleep")
     @mock.patch("pyactiveresource.activeresource.ActiveResource.find")
     def test_Locations_pyactiveresource_error_timeout_backoff(self, mocked_find, mocked_sleep):
+        """
+            Test case to verify that we backoff for 5 times when 'pyactiveresource.connection.Error' error occurs
+        """
         # mock 'find' and raise timeout error
         mocked_find.side_effect = pyactiveresource.connection.Error('urlopen error _ssl.c:1074: The handshake operation timed out')
 
@@ -286,6 +334,9 @@ class TestTimeoutBackoff(unittest.TestCase):
     @mock.patch("time.sleep")
     @mock.patch("shopify.Order.metafields")
     def test_Metafields_pyactiveresource_error_timeout_backoff(self, mocked_find, mocked_sleep):
+        """
+            Test case to verify that we backoff for 5 times when 'pyactiveresource.connection.Error' error occurs
+        """
         # mock 'find' and raise timeout error
         mocked_find.side_effect = pyactiveresource.connection.Error('urlopen error _ssl.c:1074: The handshake operation timed out')
 
@@ -301,6 +352,9 @@ class TestTimeoutBackoff(unittest.TestCase):
     @mock.patch("time.sleep")
     @mock.patch("shopify.Refund.find")
     def test_OrderRefunds_pyactiveresource_error_timeout_backoff(self, mocked_find, mocked_sleep):
+        """
+            Test case to verify that we backoff for 5 times when 'pyactiveresource.connection.Error' error occurs
+        """
         # mock 'find' and raise timeout error
         mocked_find.side_effect = pyactiveresource.connection.Error('urlopen error _ssl.c:1074: The handshake operation timed out')
 
@@ -318,6 +372,9 @@ class TestTimeoutBackoff(unittest.TestCase):
     @mock.patch("time.sleep")
     @mock.patch("pyactiveresource.activeresource.ActiveResource.find")
     def test_Transactions_pyactiveresource_error_timeout_backoff(self, mocked_find, mocked_sleep):
+        """
+            Test case to verify that we backoff for 5 times when 'pyactiveresource.connection.Error' error occurs
+        """
         # mock 'find' and raise timeout error
         mocked_find.side_effect = pyactiveresource.connection.Error('urlopen error _ssl.c:1074: The handshake operation timed out')
 
@@ -335,6 +392,9 @@ class TestTimeoutBackoff(unittest.TestCase):
     @mock.patch("time.sleep")
     @mock.patch("shopify.Shop.current")
     def test_Shop_pyactiveresource_error_timeout_backoff(self, mocked_current, mocked_sleep):
+        """
+            Test case to verify that we backoff for 5 times when 'pyactiveresource.connection.Error' error occurs
+        """
         # mock 'Shop' call and raise timeout error
         mocked_current.side_effect = pyactiveresource.connection.Error('urlopen error _ssl.c:1074: The handshake operation timed out')
 
@@ -358,6 +418,9 @@ class TestTimeoutBackoff(unittest.TestCase):
     @mock.patch("time.sleep")
     @mock.patch("shopify.Checkout.find")
     def test_AbandonedCheckouts_socket_timeout_backoff(self, mocked_find, mocked_sleep):
+        """
+            Test case to verify that we backoff for 5 times when 'socket.timeout' error occurs
+        """
         # mock 'find' and raise timeout error
         mocked_find.side_effect = socket.timeout("The read operation timed out")
 
@@ -375,6 +438,9 @@ class TestTimeoutBackoff(unittest.TestCase):
     @mock.patch("time.sleep")
     @mock.patch("shopify.InventoryItem.find")
     def test_InventoryItems_socket_timeout_backoff(self, mocked_find, mocked_sleep):
+        """
+            Test case to verify that we backoff for 5 times when 'socket.timeout' error occurs
+        """
         # mock 'find' and raise timeout error
         mocked_find.side_effect = socket.timeout("The read operation timed out")
 
@@ -392,6 +458,9 @@ class TestTimeoutBackoff(unittest.TestCase):
     @mock.patch("time.sleep")
     @mock.patch("pyactiveresource.activeresource.ActiveResource.find")
     def test_InventoryLevels_socket_timeout_backoff(self, mocked_find, mocked_sleep):
+        """
+            Test case to verify that we backoff for 5 times when 'socket.timeout' error occurs
+        """
         # mock 'find' and raise timeout error
         mocked_find.side_effect = socket.timeout("The read operation timed out")
 
@@ -409,6 +478,9 @@ class TestTimeoutBackoff(unittest.TestCase):
     @mock.patch("time.sleep")
     @mock.patch("pyactiveresource.activeresource.ActiveResource.find")
     def test_Locations_socket_timeout_backoff(self, mocked_find, mocked_sleep):
+        """
+            Test case to verify that we backoff for 5 times when 'socket.timeout' error occurs
+        """
         # mock 'find' and raise timeout error
         mocked_find.side_effect = socket.timeout("The read operation timed out")
 
@@ -426,6 +498,9 @@ class TestTimeoutBackoff(unittest.TestCase):
     @mock.patch("time.sleep")
     @mock.patch("shopify.Order.metafields")
     def test_Metafields_socket_timeout_backoff(self, mocked_find, mocked_sleep):
+        """
+            Test case to verify that we backoff for 5 times when 'socket.timeout' error occurs
+        """
         # mock 'find' and raise timeout error
         mocked_find.side_effect = socket.timeout("The read operation timed out")
 
@@ -441,6 +516,9 @@ class TestTimeoutBackoff(unittest.TestCase):
     @mock.patch("time.sleep")
     @mock.patch("shopify.Refund.find")
     def test_OrderRefunds_socket_timeout_backoff(self, mocked_find, mocked_sleep):
+        """
+            Test case to verify that we backoff for 5 times when 'socket.timeout' error occurs
+        """
         # mock 'find' and raise timeout error
         mocked_find.side_effect = socket.timeout("The read operation timed out")
 
@@ -458,6 +536,9 @@ class TestTimeoutBackoff(unittest.TestCase):
     @mock.patch("time.sleep")
     @mock.patch("pyactiveresource.activeresource.ActiveResource.find")
     def test_Transactions_socket_timeout_backoff(self, mocked_find, mocked_sleep):
+        """
+            Test case to verify that we backoff for 5 times when 'socket.timeout' error occurs
+        """
         # mock 'find' and raise timeout error
         mocked_find.side_effect = socket.timeout("The read operation timed out")
 
@@ -475,6 +556,9 @@ class TestTimeoutBackoff(unittest.TestCase):
     @mock.patch("time.sleep")
     @mock.patch("shopify.Shop.current")
     def test_Shop_socket_timeout_backoff(self, mocked_current, mocked_sleep):
+        """
+            Test case to verify that we backoff for 5 times when 'socket.timeout' error occurs
+        """
         # mock 'Shop' call and raise timeout error
         mocked_current.side_effect = socket.timeout("The read operation timed out")
 

--- a/tests/unittests/test_timeout.py
+++ b/tests/unittests/test_timeout.py
@@ -188,7 +188,7 @@ class TestTimeoutBackoff(unittest.TestCase):
 
         try:
             # function call
-            get_metafields(shopify.Order, 1, 100)
+            get_metafields(shopify.Order, 1, shopify.Order, 100)
         except pyactiveresource.connection.Error:
             pass
 

--- a/tests/unittests/test_timeout.py
+++ b/tests/unittests/test_timeout.py
@@ -1,3 +1,4 @@
+import tap_shopify
 from unittest import mock
 import pyactiveresource
 import shopify
@@ -106,6 +107,107 @@ class TestTimeoutValue(unittest.TestCase):
         stream = Stream()
         # verify the timeout is set as expected
         self.assertEquals(stream.request_timeout, 300)
+
+    @mock.patch("shopify.Shop.set_timeout")
+    @mock.patch("shopify.Shop.current")
+    def test_timeout_value_not_passed_in_config__initialize_shopify_client(self, mocked_current, mocked_set_timeout):
+        # initialize config
+        Context.config = {
+            "start_date": "2021-01-01",
+            "api_key": "test_api_key",
+            "shop": "test_shop",
+            "results_per_page": 50
+        }
+
+        # function call
+        tap_shopify.initialize_shopify_client()
+        # verify the timeout is set as expected
+        mocked_set_timeout.assert_called_with(300)
+
+    @mock.patch("shopify.Shop.set_timeout")
+    @mock.patch("shopify.Shop.current")
+    def test_timeout_int_value_passed_in_config__initialize_shopify_client(self, mocked_current, mocked_set_timeout):
+        # initialize config
+        Context.config = {
+            "start_date": "2021-01-01",
+            "api_key": "test_api_key",
+            "shop": "test_shop",
+            "results_per_page": 50,
+            "request_timeout": 100
+        }
+
+        # function call
+        tap_shopify.initialize_shopify_client()
+        # verify the timeout is set as expected
+        mocked_set_timeout.assert_called_with(100)
+
+    @mock.patch("shopify.Shop.set_timeout")
+    @mock.patch("shopify.Shop.current")
+    def test_timeout_string_value_passed_in_config__initialize_shopify_client(self, mocked_current, mocked_set_timeout):
+        # initialize config
+        Context.config = {
+            "start_date": "2021-01-01",
+            "api_key": "test_api_key",
+            "shop": "test_shop",
+            "results_per_page": 50,
+            "request_timeout": "100"
+        }
+
+        # function call
+        tap_shopify.initialize_shopify_client()
+        # verify the timeout is set as expected
+        mocked_set_timeout.assert_called_with(100)
+
+    @mock.patch("shopify.Shop.set_timeout")
+    @mock.patch("shopify.Shop.current")
+    def test_timeout_empty_value_passed_in_config__initialize_shopify_client(self, mocked_current, mocked_set_timeout):
+        # initialize config
+        Context.config = {
+            "start_date": "2021-01-01",
+            "api_key": "test_api_key",
+            "shop": "test_shop",
+            "results_per_page": 50,
+            "request_timeout": ""
+        }
+
+        # function call
+        tap_shopify.initialize_shopify_client()
+        # verify the timeout is set as expected
+        mocked_set_timeout.assert_called_with(300)
+
+    @mock.patch("shopify.Shop.set_timeout")
+    @mock.patch("shopify.Shop.current")
+    def test_timeout_0_value_passed_in_config__initialize_shopify_client(self, mocked_current, mocked_set_timeout):
+        # initialize config
+        Context.config = {
+            "start_date": "2021-01-01",
+            "api_key": "test_api_key",
+            "shop": "test_shop",
+            "results_per_page": 50,
+            "request_timeout": 0.0
+        }
+
+        # function call
+        tap_shopify.initialize_shopify_client()
+        # verify the timeout is set as expected
+        mocked_set_timeout.assert_called_with(300)
+
+    @mock.patch("shopify.Shop.set_timeout")
+    @mock.patch("shopify.Shop.current")
+    def test_timeout_string_0_value_passed_in_config__initialize_shopify_client(self, mocked_current, mocked_set_timeout):
+        # initialize config
+        Context.config = {
+            "start_date": "2021-01-01",
+            "api_key": "test_api_key",
+            "shop": "test_shop",
+            "results_per_page": 50,
+            "request_timeout": "0.0"
+        }
+
+        # function call
+        tap_shopify.initialize_shopify_client()
+        # verify the timeout is set as expected
+        mocked_set_timeout.assert_called_with(300)
 
 class TestTimeoutBackoff(unittest.TestCase):
     """
@@ -228,3 +330,22 @@ class TestTimeoutBackoff(unittest.TestCase):
 
         # verify we backoff 5 times
         self.assertEquals(mocked_find.call_count, 5)
+
+    @mock.patch("time.sleep")
+    @mock.patch("shopify.Shop.current")
+    def test_Shop_timeout_backoff(self, mocked_current, mocked_sleep):
+        # mock 'Shop' call and raise timeout error
+        mocked_current.side_effect = pyactiveresource.connection.Error('urlopen error _ssl.c:1074: The handshake operation timed out')
+
+        Context.config = {
+            "api_key": "test_api_key",
+            "shop": "test_shop"
+        }
+        try:
+            # function call
+            tap_shopify.initialize_shopify_client()
+        except pyactiveresource.connection.Error:
+            pass
+
+        # verify we backoff 5 times
+        self.assertEquals(mocked_current.call_count, 5)

--- a/tests/unittests/test_timeout.py
+++ b/tests/unittests/test_timeout.py
@@ -1,3 +1,4 @@
+import socket
 import tap_shopify
 from unittest import mock
 import pyactiveresource
@@ -216,7 +217,7 @@ class TestTimeoutBackoff(unittest.TestCase):
 
     @mock.patch("time.sleep")
     @mock.patch("shopify.Checkout.find")
-    def test_AbandonedCheckouts_timeout_backoff(self, mocked_find, mocked_sleep):
+    def test_AbandonedCheckouts_pyactiveresource_error_timeout_backoff(self, mocked_find, mocked_sleep):
         # mock 'find' and raise timeout error
         mocked_find.side_effect = pyactiveresource.connection.Error('urlopen error _ssl.c:1074: The handshake operation timed out')
 
@@ -233,7 +234,7 @@ class TestTimeoutBackoff(unittest.TestCase):
 
     @mock.patch("time.sleep")
     @mock.patch("shopify.InventoryItem.find")
-    def test_InventoryItems_timeout_backoff(self, mocked_find, mocked_sleep):
+    def test_InventoryItems_pyactiveresource_error_timeout_backoff(self, mocked_find, mocked_sleep):
         # mock 'find' and raise timeout error
         mocked_find.side_effect = pyactiveresource.connection.Error('urlopen error _ssl.c:1074: The handshake operation timed out')
 
@@ -250,7 +251,7 @@ class TestTimeoutBackoff(unittest.TestCase):
 
     @mock.patch("time.sleep")
     @mock.patch("pyactiveresource.activeresource.ActiveResource.find")
-    def test_InventoryLevels_timeout_backoff(self, mocked_find, mocked_sleep):
+    def test_InventoryLevels_pyactiveresource_error_timeout_backoff(self, mocked_find, mocked_sleep):
         # mock 'find' and raise timeout error
         mocked_find.side_effect = pyactiveresource.connection.Error('urlopen error _ssl.c:1074: The handshake operation timed out')
 
@@ -267,7 +268,7 @@ class TestTimeoutBackoff(unittest.TestCase):
 
     @mock.patch("time.sleep")
     @mock.patch("pyactiveresource.activeresource.ActiveResource.find")
-    def test_Locations_timeout_backoff(self, mocked_find, mocked_sleep):
+    def test_Locations_pyactiveresource_error_timeout_backoff(self, mocked_find, mocked_sleep):
         # mock 'find' and raise timeout error
         mocked_find.side_effect = pyactiveresource.connection.Error('urlopen error _ssl.c:1074: The handshake operation timed out')
 
@@ -284,7 +285,7 @@ class TestTimeoutBackoff(unittest.TestCase):
 
     @mock.patch("time.sleep")
     @mock.patch("shopify.Order.metafields")
-    def test_Metafields_timeout_backoff(self, mocked_find, mocked_sleep):
+    def test_Metafields_pyactiveresource_error_timeout_backoff(self, mocked_find, mocked_sleep):
         # mock 'find' and raise timeout error
         mocked_find.side_effect = pyactiveresource.connection.Error('urlopen error _ssl.c:1074: The handshake operation timed out')
 
@@ -299,7 +300,7 @@ class TestTimeoutBackoff(unittest.TestCase):
 
     @mock.patch("time.sleep")
     @mock.patch("shopify.Refund.find")
-    def test_OrderRefunds_timeout_backoff(self, mocked_find, mocked_sleep):
+    def test_OrderRefunds_pyactiveresource_error_timeout_backoff(self, mocked_find, mocked_sleep):
         # mock 'find' and raise timeout error
         mocked_find.side_effect = pyactiveresource.connection.Error('urlopen error _ssl.c:1074: The handshake operation timed out')
 
@@ -316,7 +317,7 @@ class TestTimeoutBackoff(unittest.TestCase):
 
     @mock.patch("time.sleep")
     @mock.patch("pyactiveresource.activeresource.ActiveResource.find")
-    def test_Transactions_timeout_backoff(self, mocked_find, mocked_sleep):
+    def test_Transactions_pyactiveresource_error_timeout_backoff(self, mocked_find, mocked_sleep):
         # mock 'find' and raise timeout error
         mocked_find.side_effect = pyactiveresource.connection.Error('urlopen error _ssl.c:1074: The handshake operation timed out')
 
@@ -333,7 +334,7 @@ class TestTimeoutBackoff(unittest.TestCase):
 
     @mock.patch("time.sleep")
     @mock.patch("shopify.Shop.current")
-    def test_Shop_timeout_backoff(self, mocked_current, mocked_sleep):
+    def test_Shop_pyactiveresource_error_timeout_backoff(self, mocked_current, mocked_sleep):
         # mock 'Shop' call and raise timeout error
         mocked_current.side_effect = pyactiveresource.connection.Error('urlopen error _ssl.c:1074: The handshake operation timed out')
 
@@ -345,6 +346,146 @@ class TestTimeoutBackoff(unittest.TestCase):
             # function call
             tap_shopify.initialize_shopify_client()
         except pyactiveresource.connection.Error:
+            pass
+
+        # verify we backoff 5 times
+        self.assertEquals(mocked_current.call_count, 5)
+
+    """
+        Verify the tap backoff for 5 times when timeout error occurs
+    """
+
+    @mock.patch("time.sleep")
+    @mock.patch("shopify.Checkout.find")
+    def test_AbandonedCheckouts_socket_timeout_backoff(self, mocked_find, mocked_sleep):
+        # mock 'find' and raise timeout error
+        mocked_find.side_effect = socket.timeout("The read operation timed out")
+
+        # initialize 'AbandonedCheckouts' as it calls the function 'call_api' from the base class
+        abandoned_checkouts = AbandonedCheckouts()
+        try:
+            # function call
+            abandoned_checkouts.call_api({})
+        except socket.timeout:
+            pass
+
+        # verify we backoff 5 times
+        self.assertEquals(mocked_find.call_count, 5)
+
+    @mock.patch("time.sleep")
+    @mock.patch("shopify.InventoryItem.find")
+    def test_InventoryItems_socket_timeout_backoff(self, mocked_find, mocked_sleep):
+        # mock 'find' and raise timeout error
+        mocked_find.side_effect = socket.timeout("The read operation timed out")
+
+        # initialize class
+        inventory_items = InventoryItems()
+        try:
+            # function call
+            inventory_items.get_inventory_items([1, 2, 3])
+        except socket.timeout:
+            pass
+
+        # verify we backoff 5 times
+        self.assertEquals(mocked_find.call_count, 5)
+
+    @mock.patch("time.sleep")
+    @mock.patch("pyactiveresource.activeresource.ActiveResource.find")
+    def test_InventoryLevels_socket_timeout_backoff(self, mocked_find, mocked_sleep):
+        # mock 'find' and raise timeout error
+        mocked_find.side_effect = socket.timeout("The read operation timed out")
+
+        # initialize class
+        inventory_levels = InventoryLevels()
+        try:
+            # function call
+            inventory_levels.api_call_for_inventory_levels(1, 'test')
+        except socket.timeout:
+            pass
+
+        # verify we backoff 5 times
+        self.assertEquals(mocked_find.call_count, 5)
+
+    @mock.patch("time.sleep")
+    @mock.patch("pyactiveresource.activeresource.ActiveResource.find")
+    def test_Locations_socket_timeout_backoff(self, mocked_find, mocked_sleep):
+        # mock 'find' and raise timeout error
+        mocked_find.side_effect = socket.timeout("The read operation timed out")
+
+        # initialize class
+        locations = Locations()
+        try:
+            # function call
+            locations.replication_object.find()
+        except socket.timeout:
+            pass
+
+        # verify we backoff 5 times
+        self.assertEquals(mocked_find.call_count, 5)
+
+    @mock.patch("time.sleep")
+    @mock.patch("shopify.Order.metafields")
+    def test_Metafields_socket_timeout_backoff(self, mocked_find, mocked_sleep):
+        # mock 'find' and raise timeout error
+        mocked_find.side_effect = socket.timeout("The read operation timed out")
+
+        try:
+            # function call
+            get_metafields(shopify.Order, 1, shopify.Order, 100)
+        except socket.timeout:
+            pass
+
+        # verify we backoff 5 times
+        self.assertEquals(mocked_find.call_count, 5)
+
+    @mock.patch("time.sleep")
+    @mock.patch("shopify.Refund.find")
+    def test_OrderRefunds_socket_timeout_backoff(self, mocked_find, mocked_sleep):
+        # mock 'find' and raise timeout error
+        mocked_find.side_effect = socket.timeout("The read operation timed out")
+
+        # initialize class
+        order_refunds = OrderRefunds()
+        try:
+            # function call
+            order_refunds.get_refunds(shopify.Product, 1)
+        except socket.timeout:
+            pass
+
+        # verify we backoff 5 times
+        self.assertEquals(mocked_find.call_count, 5)
+
+    @mock.patch("time.sleep")
+    @mock.patch("pyactiveresource.activeresource.ActiveResource.find")
+    def test_Transactions_socket_timeout_backoff(self, mocked_find, mocked_sleep):
+        # mock 'find' and raise timeout error
+        mocked_find.side_effect = socket.timeout("The read operation timed out")
+
+        # initialize class
+        locations = Transactions()
+        try:
+            # function call
+            locations.replication_object.find()
+        except socket.timeout:
+            pass
+
+        # verify we backoff 5 times
+        self.assertEquals(mocked_find.call_count, 5)
+
+    @mock.patch("time.sleep")
+    @mock.patch("shopify.Shop.current")
+    def test_Shop_socket_timeout_backoff(self, mocked_current, mocked_sleep):
+        # mock 'Shop' call and raise timeout error
+        mocked_current.side_effect = socket.timeout("The read operation timed out")
+
+        Context.config = {
+            "api_key": "test_api_key",
+            "shop": "test_shop"
+        }
+        try:
+            # function call
+            tap_shopify.initialize_shopify_client()
+        except socket.timeout:
             pass
 
         # verify we backoff 5 times


### PR DESCRIPTION
# Description of change
TDL-16648: Implement request timeouts
- Added request timeout for the tap, default timeout is 300 seconds.

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch
