### PR TITLE
TDL-17096 updated the write_bookmark() logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.7.1
+  * Update bookmarking logic [#143] (https://github.com/singer-io/tap-shopify/pull/143)
+
 ## 1.7.0
   From [#157](https://github.com/singer-io/tap-shopify/pull/157):
   * API/SDK Upgrade to v12.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 1.7.1
-  * Update bookmarking logic [#143] (https://github.com/singer-io/tap-shopify/pull/143)
+  * Update bookmarking logic [#143](https://github.com/singer-io/tap-shopify/pull/143)
 
 ## 1.7.0
   From [#157](https://github.com/singer-io/tap-shopify/pull/157):

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-shopify",
-    version="1.7.0",
+    version="1.7.1",
     description="Singer.io tap for extracting Shopify data",
     author="Stitch",
     url="http://github.com/singer-io/tap-shopify",

--- a/tap_shopify/streams/base.py
+++ b/tap_shopify/streams/base.py
@@ -225,8 +225,7 @@ class Stream():
                     # window and can move forward. Also remove the since_id because we want to
                     # restart at 1.
                     Context.state.get('bookmarks', {}).get(self.name, {}).pop('since_id', None)
-                    bookmark = max(min(stop_time, max_bookmark), (stop_time - datetime.timedelta(days=date_window_size))) #pylint: disable=line-too-long
-                    self.update_bookmark(utils.strftime(bookmark))
+                    self.update_bookmark(utils.strftime(updated_at_max))
                     break
 
                 if objects[-1].id != max([o.id for o in objects]):
@@ -239,6 +238,8 @@ class Stream():
 
                 # Put since_id into the state.
                 self.update_bookmark(since_id, bookmark_key='since_id')
+            bookmark = max(min(stop_time, max_bookmark), (stop_time - datetime.timedelta(days=date_window_size))) #pylint: disable=line-too-long
+            self.update_bookmark(utils.strftime(bookmark))
 
             updated_at_min = updated_at_max
 

--- a/tap_shopify/streams/base.py
+++ b/tap_shopify/streams/base.py
@@ -135,7 +135,8 @@ class Stream():
         return utils.strptime_with_tz(bookmark)
 
     def get_since_id(self):
-        LOGGER.info(f'>>>>>> state {Context.state}')
+        LOGGER.info('>>>>>> state')
+        LOGGER.info(Context.state)
         return singer.get_bookmark(Context.state,
                                    # name is overridden by some substreams
                                    self.name,

--- a/tap_shopify/streams/base.py
+++ b/tap_shopify/streams/base.py
@@ -206,14 +206,13 @@ class Stream():
                     objects = self.call_api(query_params)
 
                 for obj in objects:
-                    dict_obj = obj.to_dict()
-                    replication_value = strptime_to_utc(dict_obj[self.replication_key])
                     if obj.id < since_id:
                         # This verifies the api behavior expectation we
                         # have that all results actually honor the
                         # since_id parameter.
                         raise OutOfOrderIdsError("obj.id < since_id: {} < {}".format(
                             obj.id, since_id))
+                    replication_value = strptime_to_utc(getattr(obj, self.replication_key))
                     if replication_value > max_bookmark:
                         max_bookmark = replication_value
                     yield obj
@@ -240,7 +239,9 @@ class Stream():
                 self.update_bookmark(since_id, bookmark_key='since_id')
 
             updated_at_min = updated_at_max
-        bookmark = max(min(stop_time, max_bookmark), (stop_time - datetime.timedelta(days=date_window_size))) #pylint: disable=line-too-long
+        bookmark = max(min(stop_time,
+                           max_bookmark),
+                       (stop_time - datetime.timedelta(days=date_window_size)))
         self.update_bookmark(utils.strftime(bookmark))
 
     def sync(self):

--- a/tap_shopify/streams/base.py
+++ b/tap_shopify/streams/base.py
@@ -135,8 +135,6 @@ class Stream():
         return utils.strptime_with_tz(bookmark)
 
     def get_since_id(self):
-        LOGGER.info('>>>>>> state')
-        LOGGER.info(Context.state)
         return singer.get_bookmark(Context.state,
                                    # name is overridden by some substreams
                                    self.name,

--- a/tap_shopify/streams/base.py
+++ b/tap_shopify/streams/base.py
@@ -225,7 +225,7 @@ class Stream():
                     # window and can move forward. Also remove the since_id because we want to
                     # restart at 1.
                     Context.state.get('bookmarks', {}).get(self.name, {}).pop('since_id', None)
-                    bookmark = max(min(stop_time, max_bookmark), (stop_time - datetime.timedelta(days=date_window_size)))
+                    bookmark = max(min(stop_time, max_bookmark), (stop_time - datetime.timedelta(days=date_window_size))) #pylint: disable=line-too-long
                     self.update_bookmark(utils.strftime(bookmark))
                     break
 

--- a/tap_shopify/streams/base.py
+++ b/tap_shopify/streams/base.py
@@ -135,6 +135,7 @@ class Stream():
         return utils.strptime_with_tz(bookmark)
 
     def get_since_id(self):
+        LOGGER.info(f'>>>>>> state {Context.state}')
         return singer.get_bookmark(Context.state,
                                    # name is overridden by some substreams
                                    self.name,

--- a/tap_shopify/streams/base.py
+++ b/tap_shopify/streams/base.py
@@ -238,8 +238,6 @@ class Stream():
 
                 # Put since_id into the state.
                 self.update_bookmark(since_id, bookmark_key='since_id')
-            # bookmark = max(min(stop_time, max_bookmark), (stop_time - datetime.timedelta(days=date_window_size))) #pylint: disable=line-too-long
-            # self.update_bookmark(utils.strftime(bookmark))
 
             updated_at_min = updated_at_max
         bookmark = max(min(stop_time, max_bookmark), (stop_time - datetime.timedelta(days=date_window_size))) #pylint: disable=line-too-long

--- a/tap_shopify/streams/base.py
+++ b/tap_shopify/streams/base.py
@@ -238,10 +238,12 @@ class Stream():
 
                 # Put since_id into the state.
                 self.update_bookmark(since_id, bookmark_key='since_id')
-            bookmark = max(min(stop_time, max_bookmark), (stop_time - datetime.timedelta(days=date_window_size))) #pylint: disable=line-too-long
-            self.update_bookmark(utils.strftime(bookmark))
+            # bookmark = max(min(stop_time, max_bookmark), (stop_time - datetime.timedelta(days=date_window_size))) #pylint: disable=line-too-long
+            # self.update_bookmark(utils.strftime(bookmark))
 
             updated_at_min = updated_at_max
+        bookmark = max(min(stop_time, max_bookmark), (stop_time - datetime.timedelta(days=date_window_size))) #pylint: disable=line-too-long
+        self.update_bookmark(utils.strftime(bookmark))
 
     def sync(self):
         """Yield's processed SDK object dicts to the caller.

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -29,6 +29,10 @@ class BookmarkTest(BaseTapTest):
         """
         max_bookmarks = {}
         for stream, batch in sync_records.items():
+            # The metafields fetches the fields from `products`, `customers`, `orders` and `custom_collections`
+            # if the parent streams are selected along with the `shop` fields.
+            # These different streams have its own bookmark based on its parent.
+            # Hence filtered out the main records i.e. the `shop` records from all the records.
             if stream != 'metafields':
                 upsert_messages = [m for m in batch.get('messages') if m['action'] == 'upsert']
             else:

--- a/tests/test_bookmarks_updated.py
+++ b/tests/test_bookmarks_updated.py
@@ -43,7 +43,7 @@ class BookmarkTest(BaseTapTest):
         # Our test data sets for Shopify do not have any abandoned_checkouts
         our_catalogs = [catalog for catalog in found_catalogs if
                         catalog.get('tap_stream_id') in incremental_streams]
-        self.select_all_streams_and_fields(conn_id, our_catalogs, select_all_fields=False)
+        self.select_all_streams_and_fields(conn_id, our_catalogs, select_all_fields=True)
 
         #################################
         # Run first sync
@@ -95,10 +95,21 @@ class BookmarkTest(BaseTapTest):
                 # information required for assertions from sync 1 and 2 based on expected values
                 first_sync_count = first_sync_record_count.get(stream, 0)
                 second_sync_count = second_sync_record_count.get(stream, 0)
-                first_sync_messages = [record.get('data') for record in first_sync_records.get(stream, {}).get('messages', [])
-                                       if record.get('action') == 'upsert']
-                second_sync_messages = [record.get('data') for record in second_sync_records.get(stream, {}).get('messages', [])
-                                        if record.get('action') == 'upsert']
+
+                if stream != 'metafields':
+                    first_sync_messages = [record.get('data') for record in first_sync_records.get(stream, {}).get('messages', [])
+                                           if record.get('action') == 'upsert']
+                else:
+                    first_sync_messages = [record.get('data') for record in first_sync_records.get(stream, {}).get('messages', [])
+                                           if record.get('action') == 'upsert' and record.get('data').get('owner_resource') == 'shop']
+
+                if stream != 'metafields':
+                    second_sync_messages = [record.get('data') for record in second_sync_records.get(stream, {}).get('messages', [])
+                                            if record.get('action') == 'upsert']
+                else:
+                    second_sync_messages = [record.get('data') for record in second_sync_records.get(stream, {}).get('messages', [])
+                                        if record.get('action') == 'upsert' and record.get('data').get('owner_resource') == 'shop']
+
                 first_bookmark_value = first_sync_bookmark.get('bookmarks', {stream: None}).get(stream)
                 first_bookmark_value = list(first_bookmark_value.values())[0]
                 second_bookmark_value = second_sync_bookmark.get('bookmarks', {stream: None}).get(stream)

--- a/tests/test_bookmarks_updated.py
+++ b/tests/test_bookmarks_updated.py
@@ -96,6 +96,10 @@ class BookmarkTest(BaseTapTest):
                 first_sync_count = first_sync_record_count.get(stream, 0)
                 second_sync_count = second_sync_record_count.get(stream, 0)
 
+                # The metafields fetches the fields from `products`, `customers`, `orders` and `custom_collections`
+                # if the parent streams are selected along with the `shop` fields.
+                # These different streams have its own bookmark based on its parent.
+                # Hence filtered out the main records i.e. the `shop` records from all the records.
                 if stream != 'metafields':
                     first_sync_messages = [record.get('data') for record in first_sync_records.get(stream, {}).get('messages', [])
                                            if record.get('action') == 'upsert']

--- a/tests/unittests/test_updated_bookmark.py
+++ b/tests/unittests/test_updated_bookmark.py
@@ -7,6 +7,7 @@ import datetime
 from tap_shopify.streams.base import DATE_WINDOW_SIZE
 
 CUSTOMER_OBJECT = Context.stream_objects['customers']()
+Context.state = {}
 
 class Customer():
     """The customer object to return in th api call"""

--- a/tests/unittests/test_updated_bookmark.py
+++ b/tests/unittests/test_updated_bookmark.py
@@ -1,6 +1,6 @@
 import unittest
 from unittest import mock
-from singer.utils import strptime_with_tz, strftime, strptime_to_utc
+from singer.utils import strftime, strptime_to_utc
 from tap_shopify.context import Context
 import datetime
 
@@ -26,7 +26,7 @@ NOW_TIME = '2021-08-16T01:56:05-04:00'
 class TestUpdateBookmark(unittest.TestCase):
 
     @mock.patch("tap_shopify.streams.base.Stream.call_api")
-    @mock.patch("tap_shopify.streams.base.Stream.get_bookmark", return_value=strptime_with_tz('2021-08-11T01:55:05-04:00'))
+    @mock.patch("tap_shopify.streams.base.Stream.get_bookmark", return_value=strptime_to_utc('2021-08-11T01:55:05-04:00'))
     @mock.patch("tap_shopify.streams.base.Stream.update_bookmark")
     @mock.patch("tap_shopify.streams.base.Stream.get_query_params")
     @mock.patch("singer.utils.now", return_value=strptime_to_utc(NOW_TIME))

--- a/tests/unittests/test_updated_bookmark.py
+++ b/tests/unittests/test_updated_bookmark.py
@@ -1,0 +1,38 @@
+import unittest
+from unittest import mock
+from singer.utils import strptime_with_tz, strftime, strptime_to_utc
+from tap_shopify.context import Context
+import datetime
+
+from tap_shopify.streams.base import DATE_WINDOW_SIZE
+
+CUSTOMER_OBJECT = Context.stream_objects['customers']()
+
+class Customer():
+    """The customer object to return in th api call"""
+    def __init__(self, id, updated_at):
+        self.id = id
+        self.updated_at = updated_at
+
+    def to_dict(self):
+        return {"id": self.id, "updated_at": self.updated_at}
+
+
+CUSTOMER_1 = Customer(2, "2021-08-11T01:57:05-04:00")
+CUSTOMER_2 = Customer(3, "2021-08-12T01:57:05-04:00")
+
+NOW_TIME = '2021-08-16T01:56:05-04:00'
+class TestUpdateBookmark(unittest.TestCase):
+
+    @mock.patch("tap_shopify.streams.base.Stream.call_api")
+    @mock.patch("tap_shopify.streams.base.Stream.get_bookmark", return_value=strptime_with_tz('2021-08-11T01:55:05-04:00'))
+    @mock.patch("tap_shopify.streams.base.Stream.update_bookmark")
+    @mock.patch("tap_shopify.streams.base.Stream.get_query_params")
+    @mock.patch("singer.utils.now", return_value=strptime_to_utc(NOW_TIME))
+    def test_update_bookmark(self, mock_now, mock_get_query_params, mock_update_bookmark, mock_get_bookmark, mock_call_api):
+        """Verify that the update_bookmark() is called with correct argument"""
+        mock_call_api.return_value = [CUSTOMER_1, CUSTOMER_2]
+
+        customers = list(CUSTOMER_OBJECT.get_objects())
+        # Verify that the min-max evaluation returns correct results and provided in the update_bookmark()
+        mock_update_bookmark.assert_called_with(strftime(strptime_to_utc(NOW_TIME) - datetime.timedelta(DATE_WINDOW_SIZE)))


### PR DESCRIPTION
# Description of change
- Updated the bookmark written for base streams. 
    - bookmark on the lesser of the maximum replication key value and the start time of sync execution. 
- Added unittests for the same

# QA steps
- Check that the correct bookmark is written based on min-max evaluation
- was pr-alpha'd to two separate clients, but without feedback if it fixed their data discrepancies. 

# Risks
- the tap will likely take longer with extra api calls because of the new bookmarking. performance testing was done in this card: https://jira.talendforge.org/browse/TDL-17096
# Rollback steps
 - revert this branch
