### PR TITLE
TDL-6829 added backoff for incompleteread error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.7.4
+  * Add backoff for IncompleteRead [#144](https://github.com/singer-io/tap-shopify/pull/144)
+
 ## 1.7.3
   * Update interrupted sync bookmark strategy [#166](https://github.com/singer-io/tap-shopify/pull/166)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-shopify",
-    version="1.7.3",
+    version="1.7.4",
     description="Singer.io tap for extracting Shopify data",
     author="Stitch",
     url="http://github.com/singer-io/tap-shopify",

--- a/tap_shopify/streams/base.py
+++ b/tap_shopify/streams/base.py
@@ -4,12 +4,12 @@ import math
 import sys
 import socket
 from urllib.error import URLError
+import http
 import backoff
 import pyactiveresource
 import pyactiveresource.formats
 import simplejson
 import singer
-import http
 from singer import metrics, utils
 from singer.utils import strptime_to_utc
 from tap_shopify.context import Context

--- a/tests/unittests/test_backoff_on_incompleteread_error.py
+++ b/tests/unittests/test_backoff_on_incompleteread_error.py
@@ -1,0 +1,24 @@
+from unittest import mock
+from tap_shopify.streams.base import http
+from tap_shopify.streams.transactions import Transactions
+import unittest
+
+class TestIncompleteReadBackoff(unittest.TestCase):
+    @mock.patch("time.sleep")
+    @mock.patch("pyactiveresource.activeresource.ActiveResource.find")
+    def test_Transactions_pyactiveresource_error_incomplete_read_error_backoff(self, mocked_find, mocked_sleep):
+        """
+            Test case to verify that we backoff for 5 times when 'http.client.IncompleteRead' error occurs
+        """
+        # mock 'find' and raise IncompleteRead error
+        mocked_find.side_effect = http.client.IncompleteRead(b'')
+        # initialize class
+        locations = Transactions()
+        try:
+            # function call
+            locations.replication_object.find()
+        except http.client.IncompleteRead:
+            pass
+
+        # verify we backoff 5 times
+        self.assertEquals(mocked_find.call_count, 5)


### PR DESCRIPTION
# Description of change
- Added backoff for 5 times in case of http.client.IncompleteRead error
- Added unittests to ensure the same

# QA steps
 - Verify that the tap backoffs 5 times for http.client.IncompleteRead error
 
# Risks

# Rollback steps
 - revert this branch
