### PR TITLE
Canonicalize transactions in OrderRefunds for TDL-21280

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,18 @@
 # Changelog
 
+## 1.6.2
+  * Add canonicalization of transaction receipts to OrderRefunds [#156] (https://github.com/singer-io/tap-shopify/pull/156)
+
 ## 1.6.1
   * Fixing Tranformation Issues [#149] (https://github.com/singer-io/tap-shopify/pull/149)
+
 ## 1.6.0
   * API/SDK Upgrade to v10.0.0 [#135] (https://github.com/singer-io/tap-shopify/pull/135)
   * New Field Additions to Schema [#140] (https://github.com/singer-io/tap-shopify/pull/140)
 
 ## 1.5.1
   * Request Timeout Implementation [#129](https://github.com/singer-io/tap-shopify/pull/129)
+
 ## 1.5.0
   * Adds `events` stream [#127](https://github.com/singer-io/tap-shopify/pull/127)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-shopify",
-    version="1.6.1",
+    version="1.6.2",
     description="Singer.io tap for extracting Shopify data",
     author="Stitch",
     url="http://github.com/singer-io/tap-shopify",

--- a/tap_shopify/streams/base.py
+++ b/tap_shopify/streams/base.py
@@ -25,6 +25,47 @@ DATE_WINDOW_SIZE = 1
 # We will retry a 500 error a maximum of 5 times before giving up
 MAX_RETRIES = 5
 
+# We have observed transactions with receipt objects that contain both:
+#   - `token` and `Token`
+#   - `version` and `Version`
+#   - `ack` and `Ack`
+# keys on transactions where PayPal is the payment type. We reached out to
+# PayPal support and they told us the values should be the same, so one
+# can be safely ignored since its a duplicate. Example: The logic is to
+# prefer `token` if both are present and equal, convert `Token` -> `token`
+# if only `Token` is present, and throw an error if both are present and
+# their values are not equal.
+def canonicalize(transaction_dict, field_name):
+    field_name_upper = field_name.capitalize()
+    # Not all Shopify transactions have receipts. Facebook has been shown
+    # to push a null receipt through the transaction
+    receipt = transaction_dict.get('receipt', {})
+    if receipt:
+        value_lower = receipt.get(field_name)
+        value_upper = receipt.get(field_name_upper)
+        if value_lower and value_upper:
+            if value_lower == value_upper:
+                LOGGER.info((
+                    "Transaction (id=%d) contains a receipt "
+                    "that has `%s` and `%s` keys with the same "
+                    "value. Removing the `%s` key."),
+                            transaction_dict['id'],
+                            field_name,
+                            field_name_upper,
+                            field_name_upper)
+                transaction_dict['receipt'].pop(field_name_upper)
+            else:
+                raise ValueError((
+                    "Found Transaction (id={}) with a receipt that has "
+                    "`{}` and `{}` keys with the different "
+                    "values. Contact Shopify/PayPal support.").format(
+                        transaction_dict['id'],
+                        field_name_upper,
+                        field_name))
+        elif value_upper:
+            # pylint: disable=line-too-long
+            transaction_dict["receipt"][field_name] = transaction_dict['receipt'].pop(field_name_upper)
+
 # function to return request timeout
 def get_request_timeout():
 

--- a/tap_shopify/streams/order_refunds.py
+++ b/tap_shopify/streams/order_refunds.py
@@ -4,6 +4,7 @@ from tap_shopify.context import Context
 from tap_shopify.streams.base import (Stream,
                                       shopify_error_handling,
                                       OutOfOrderIdsError)
+from tap_shopify.streams.transactions import canonicalize
 
 class OrderRefunds(Stream):
     name = 'order_refunds'
@@ -48,6 +49,9 @@ class OrderRefunds(Stream):
             refund_dict = refund.to_dict()
             replication_value = strptime_to_utc(refund_dict[self.replication_key])
             if replication_value >= bookmark:
+                for transaction_dict in refund_dict["transactions"]:
+                    for field_name in ['token', 'version', 'ack', 'timestamp', 'build']:
+                        canonicalize(transaction_dict, field_name)
                 yield refund_dict
 
             if replication_value > max_bookmark:

--- a/tap_shopify/streams/order_refunds.py
+++ b/tap_shopify/streams/order_refunds.py
@@ -3,8 +3,8 @@ from singer.utils import strftime, strptime_to_utc
 from tap_shopify.context import Context
 from tap_shopify.streams.base import (Stream,
                                       shopify_error_handling,
-                                      OutOfOrderIdsError)
-from tap_shopify.streams.transactions import canonicalize
+                                      OutOfOrderIdsError,
+                                      canonicalize)
 
 class OrderRefunds(Stream):
     name = 'order_refunds'
@@ -49,7 +49,7 @@ class OrderRefunds(Stream):
             refund_dict = refund.to_dict()
             replication_value = strptime_to_utc(refund_dict[self.replication_key])
             if replication_value >= bookmark:
-                for transaction_dict in refund_dict["transactions"]:
+                for transaction_dict in refund_dict.get("transactions",[]):
                     for field_name in ['token', 'version', 'ack', 'timestamp', 'build']:
                         canonicalize(transaction_dict, field_name)
                 yield refund_dict

--- a/tap_shopify/streams/transactions.py
+++ b/tap_shopify/streams/transactions.py
@@ -3,54 +3,14 @@ import singer
 from singer.utils import strftime, strptime_to_utc
 from tap_shopify.context import Context
 from tap_shopify.streams.base import (Stream,
-                                      shopify_error_handling)
+                                      shopify_error_handling,
+                                      canonicalize)
 
 LOGGER = singer.get_logger()
 
 # https://help.shopify.com/en/api/reference/orders/transaction An
 # order can have no more than 100 transactions associated with it.
 TRANSACTIONS_RESULTS_PER_PAGE = 100
-
-# We have observed transactions with receipt objects that contain both:
-#   - `token` and `Token`
-#   - `version` and `Version`
-#   - `ack` and `Ack`
-# keys transactions where PayPal is the payment type. We reached out to
-# PayPal support and they told us the values should be the same, so one
-# can be safely ignored since its a duplicate. Example: The logic is to
-# prefer `token` if both are present and equal, convert `Token` -> `token`
-# if only `Token` is present, and throw an error if both are present and
-# their values are not equal
-def canonicalize(transaction_dict, field_name):
-    field_name_upper = field_name.capitalize()
-    # Not all Shopify transactions have receipts. Facebook has been shown
-    # to push a null receipt through the transaction
-    receipt = transaction_dict.get('receipt', {})
-    if receipt:
-        value_lower = receipt.get(field_name)
-        value_upper = receipt.get(field_name_upper)
-        if value_lower and value_upper:
-            if value_lower == value_upper:
-                LOGGER.info((
-                    "Transaction (id=%d) contains a receipt "
-                    "that has `%s` and `%s` keys with the same "
-                    "value. Removing the `%s` key."),
-                            transaction_dict['id'],
-                            field_name,
-                            field_name_upper,
-                            field_name_upper)
-                transaction_dict['receipt'].pop(field_name_upper)
-            else:
-                raise ValueError((
-                    "Found Transaction (id={}) with a receipt that has "
-                    "`{}` and `{}` keys with the different "
-                    "values. Contact Shopify/PayPal support.").format(
-                        transaction_dict['id'],
-                        field_name_upper,
-                        field_name))
-        elif value_upper:
-            # pylint: disable=line-too-long
-            transaction_dict["receipt"][field_name] = transaction_dict['receipt'].pop(field_name_upper)
 
 
 class Transactions(Stream):


### PR DESCRIPTION
# Description of change
- Moves canonicalization to base
- Adds canonicalization use to OrderRefunds (in addition to transactions)

# QA steps
 - [x] automated tests passing
 - [x] manual qa steps passing (list below)
   - Ran tap locally and validated output.
 
# Risks
 - If users have built reports on the uppercase versions of these fields, those would break.

# Rollback steps
 - revert this branch
