### PR TITLE
API version upgrade and schema changes 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.7.0
+  From [#157](https://github.com/singer-io/tap-shopify/pull/157):
+  * API/SDK Upgrade to v12.0.1
+  * New Field Additions to Schema
+  * Fields removal from the schema
+
 ## 1.6.2
   * Add canonicalization of transaction receipts to OrderRefunds [#156] (https://github.com/singer-io/tap-shopify/pull/156)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-shopify",
-    version="1.6.2",
+    version="1.7.0",
     description="Singer.io tap for extracting Shopify data",
     author="Stitch",
     url="http://github.com/singer-io/tap-shopify",

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     python_requires='>=3.5.2',
     py_modules=["tap_shopify"],
     install_requires=[
-        "ShopifyAPI==10.0.0",
+        "ShopifyAPI==12.0.1",
         "singer-python==5.12.1",
     ],
     extras_require={

--- a/tap_shopify/__init__.py
+++ b/tap_shopify/__init__.py
@@ -25,7 +25,7 @@ SDC_KEYS = {'id': 'integer', 'name': 'string', 'myshopify_domain': 'string'}
 def initialize_shopify_client():
     api_key = Context.config['api_key']
     shop = Context.config['shop']
-    version = '2022-01'
+    version = '2022-07'
     session = shopify.Session(shop, version, api_key)
     shopify.ShopifyResource.activate_session(session)
 

--- a/tap_shopify/schemas/definitions.json
+++ b/tap_shopify/schemas/definitions.json
@@ -455,6 +455,457 @@
           "string"
         ]
       },
+      "email_marketing_consent": {
+        "type": [
+          "null",
+          "object"
+        ],
+        "properties": {
+          "state": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "opt_in_level": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "consent_updated_at": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "date-time"
+          }
+        }
+      },
+      "sms_marketing_consent": {
+        "type": [
+          "null",
+          "object"
+        ],
+        "properties": {
+          "state": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "opt_in_level": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "consent_updated_at": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "date-time"
+          },
+          "consent_collected_from": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      }
+    }
+  },
+  "customer_orders": {
+    "type": [
+      "null",
+      "object"
+    ],
+    "properties": {
+      "currency": {
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      "email": {
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      "multipass_identifier": {
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      "default_address": {
+        "type": [
+          "null",
+          "object"
+        ],
+        "properties": {
+          "city": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "address1": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "zip": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "id": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          },
+          "country_name": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "province": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "phone": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "country": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "first_name": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "customer_id": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          },
+          "default": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
+          "last_name": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "country_code": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "name": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "province_code": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "address2": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "company": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      },
+      "state": {
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      "verified_email": {
+        "type": [
+          "null",
+          "boolean"
+        ]
+      },
+      "first_name": {
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      "updated_at": {
+        "type": [
+          "null",
+          "string"
+        ],
+        "format": "date-time"
+      },
+      "note": {
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      "phone": {
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      "admin_graphql_api_id": {
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      "addresses": {
+        "type": [
+          "null",
+          "array"
+        ],
+        "items": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "properties": {
+            "city": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "address1": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "zip": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "id": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            },
+            "country_name": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "province": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "phone": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "country": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "first_name": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "customer_id": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            },
+            "default": {
+              "type": [
+                "null",
+                "boolean"
+              ]
+            },
+            "last_name": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "country_code": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "name": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "province_code": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "address2": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "company": {
+              "type": [
+                "null",
+                "string"
+              ]
+            }
+          }
+        }
+      },
+      "last_name": {
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      "tags": {
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      "tax_exempt": {
+        "type": [
+          "null",
+          "boolean"
+        ]
+      },
+      "id": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "accepts_marketing": {
+        "type": [
+          "null",
+          "boolean"
+        ]
+      },
+      "accepts_marketing_updated_at": {
+        "anyOf": [
+          {
+            "type": "string" ,
+            "format": "date-time"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "created_at": {
+        "type": [
+          "null",
+          "string"
+        ],
+        "format": "date-time"
+      },
+      "tax_exemptions": {
+        "type": [
+          "null",
+          "array"
+        ],
+        "items": {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
+      },
+      "marketing_opt_in_level": {
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      "email_marketing_consent": {
+        "type": [
+          "null",
+          "object"
+        ],
+        "properties": {
+          "state": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "opt_in_level": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "consent_updated_at": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "date-time"
+          }
+        }
+      },
       "sms_marketing_consent": {
         "type": [
           "null",

--- a/tap_shopify/schemas/orders.json
+++ b/tap_shopify/schemas/orders.json
@@ -399,7 +399,7 @@
       ]
     },
     "customer": {
-      "$ref": "definitions.json#/customer"
+      "$ref": "definitions.json#/customer_orders"
     },
     "test": {
       "type": [


### PR DESCRIPTION
# Description of change
- Updated ShopifyAPI and SDK version
- Removed the below fields from the `customers` object of `orders` streams: 

    **last_order_id**
    **last_order_name**
    **orders_count**
    **total_spent**

- Added **email_marketing_consent** object in the `customers` stream and in the `orders` stream.

**Reference Links:**

  - Doc link: https://shopify.dev/api/admin-rest
  - Release notes: 
                   1. https://shopify.dev/api/release-notes/2022-07#breaking-changes
                   2. https://shopify.dev/api/admin-rest/2022-07/resources/customer

# QA steps
 - [ ] automated tests passing
 - [ ] manual QA steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch
