### PR TITLE
Bump Version for Shopify for API/SDK Upgrade to v12.0.1 and schema changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.7.0
+  From [#157](https://github.com/singer-io/tap-shopify/pull/157):
+  * API/SDK Upgrade to v12.0.1
+  * New Field Additions to Schema
+  * Fields removal from the schema
+
 ## 1.6.2
   * Add canonicalization of transaction receipts to OrderRefunds [#156] (https://github.com/singer-io/tap-shopify/pull/156)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-shopify",
-    version="1.6.2",
+    version="1.7.0",
     description="Singer.io tap for extracting Shopify data",
     author="Stitch",
     url="http://github.com/singer-io/tap-shopify",


### PR DESCRIPTION
# Description of change
Changes in the CHANGELOG.md and setup.py related to API/SDK version upgrade

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch
