### PR TITLE
Update platform type for tap-tester tests

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -37,7 +37,7 @@ class BaseTapTest(BaseCase):
     @staticmethod
     def get_type():
         """the expected url route ending"""
-        return "platform.shopify"
+        return "platform.shopify-tba"
 
     def get_properties(self, original: bool = True):
         """Configuration properties required for the tap."""


### PR DESCRIPTION
# Description of change
Update platform integration type for tap-tester tests.  An associated environments repo update is needed for the new API key.

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch
