### PR TITLE
TDL-22858 Add URLError to backoff handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.7.2
+  * Add URLError (connection reset by peer) to retry logic [#165](https://github.com/singer-io/tap-shopify/pull/165)
+
 ## 1.7.1
   * Update bookmarking logic [#143](https://github.com/singer-io/tap-shopify/pull/143)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-shopify",
-    version="1.7.1",
+    version="1.7.2",
     description="Singer.io tap for extracting Shopify data",
     author="Stitch",
     url="http://github.com/singer-io/tap-shopify",

--- a/tap_shopify/streams/base.py
+++ b/tap_shopify/streams/base.py
@@ -3,6 +3,7 @@ import functools
 import math
 import sys
 import socket
+from urllib.error import URLError
 import backoff
 import pyactiveresource
 import pyactiveresource.formats
@@ -127,7 +128,8 @@ def shopify_error_handling(fnc):
     @backoff.on_exception(backoff.expo,
                           (pyactiveresource.connection.ServerError,
                            pyactiveresource.formats.Error,
-                           simplejson.scanner.JSONDecodeError),
+                           simplejson.scanner.JSONDecodeError,
+                            URLError),
                           giveup=is_not_status_code_fn(range(500, 599)),
                           on_backoff=retry_handler,
                           max_tries=MAX_RETRIES)

--- a/tap_shopify/streams/base.py
+++ b/tap_shopify/streams/base.py
@@ -129,7 +129,7 @@ def shopify_error_handling(fnc):
                           (pyactiveresource.connection.ServerError,
                            pyactiveresource.formats.Error,
                            simplejson.scanner.JSONDecodeError,
-                            URLError),
+                           URLError),
                           giveup=is_not_status_code_fn(range(500, 599)),
                           on_backoff=retry_handler,
                           max_tries=MAX_RETRIES)

--- a/tests/unittests/test_error_handling.py
+++ b/tests/unittests/test_error_handling.py
@@ -1,0 +1,23 @@
+import unittest
+from unittest.mock import Mock
+from urllib.error import URLError
+import tap_shopify
+from tap_shopify.context import Context
+
+
+class TestShopifyConnectionResetErrorHandling(unittest.TestCase):
+
+    def test_check_access_handle_timeout_error(self):
+        '''
+        Test retry handling of URLError
+        '''
+
+        stream = Context.stream_objects['orders']()
+        stream.replication_object = Mock()
+        stream.replication_object.find = Mock()
+        stream.replication_object.find.side_effect = URLError('<urlopen error [Errno 104] Connection reset by peer>')
+
+        with self.assertRaises(URLError):
+            stream.call_api({})
+
+        self.assertEqual(stream.replication_object.find.call_count, 5)


### PR DESCRIPTION
# Description of change
- Adds URLError (connection reset by peer) to existing backoff handling
- Adds unittest
- changelog + version bump

# QA steps
 - [x] automated tests passing
 - [x] manual qa steps passing (list below)
   - Wrote unittest that is passing
 
# Risks
- Negligible; adds backoff handling for very rare error

# Rollback steps
 - revert this branch
