### PR TITLE
update bookmarking for interrupted sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.7.3
+  * Update interrupted sync bookmark strategy [#166](https://github.com/singer-io/tap-shopify/pull/166)
+
 ## 1.7.2
   * Add URLError (connection reset by peer) to retry logic [#165](https://github.com/singer-io/tap-shopify/pull/165)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-shopify",
-    version="1.7.2",
+    version="1.7.3",
     description="Singer.io tap for extracting Shopify data",
     author="Stitch",
     url="http://github.com/singer-io/tap-shopify",

--- a/tap_shopify/streams/base.py
+++ b/tap_shopify/streams/base.py
@@ -184,8 +184,8 @@ class Stream():
                                    'since_id')
 
     def get_updated_at_max(self):
-        return utils.strptime_with_tz(
-            Context.state.get('bookmarks', {}).get(self.name, {}).get('updated_at_max'))
+        updated_at_max = Context.state.get('bookmarks', {}).get(self.name, {}).get('updated_at_max')
+        return utils.strptime_with_tz(updated_at_max) if updated_at_max else None
 
     def update_bookmark(self, bookmark_value, bookmark_key=None):
         # NOTE: Bookmarking can never be updated to not get the most

--- a/tap_shopify/streams/base.py
+++ b/tap_shopify/streams/base.py
@@ -278,9 +278,9 @@ class Stream():
                     # Save the updated_at_max as our bookmark as we've synced all rows up in our
                     # window and can move forward. Also remove the since_id because we want to
                     # restart at 1.
-                    Context.state.get('bookmarks', {}).get(self.name, {}).pop('since_id', None)
-                    Context.state.get('bookmarks', {}).get(
-                        self.name, {}).pop('updated_at_max', None)
+                    stream_bookmarks = Context.state.get('bookmarks', {}).get(self.name, {})
+                    stream_bookmarks.pop('since_id', None)
+                    stream_bookmarks.pop('updated_at_max', None)
                     self.update_bookmark(utils.strftime(updated_at_max))
                     break
 

--- a/tap_shopify/streams/base.py
+++ b/tap_shopify/streams/base.py
@@ -244,8 +244,8 @@ class Stream():
             # updated_at_max bookmarked in the interrupted sync.
             # This will make sure that records with lower id than since_id
             # which got updated later won't be missed
-            updated_at_max = last_sync_interrupted_at or updated_at_min + \
-                datetime.timedelta(days=date_window_size)
+            updated_at_max = (last_sync_interrupted_at
+                              or updated_at_min + datetime.timedelta(days=date_window_size))
             last_sync_interrupted_at = None
 
             if updated_at_max > stop_time:

--- a/tap_shopify/streams/base.py
+++ b/tap_shopify/streams/base.py
@@ -183,6 +183,10 @@ class Stream():
                                    self.name,
                                    'since_id')
 
+    def get_updated_at_max(self):
+        return utils.strptime_with_tz(
+            Context.state.get('bookmarks', {}).get(self.name, {}).get('updated_at_max'))
+
     def update_bookmark(self, bookmark_value, bookmark_key=None):
         # NOTE: Bookmarking can never be updated to not get the most
         # recent thing it saw the next time you run, because the querying
@@ -216,6 +220,7 @@ class Stream():
         }
 
     def get_objects(self):
+        last_sync_interrupted_at = self.get_updated_at_max()
         updated_at_min = self.get_bookmark()
         max_bookmark = updated_at_min
 
@@ -235,7 +240,14 @@ class Stream():
             # think it has something to do with how the API treats
             # microseconds on its date windows. Maybe it's possible to
             # drop data due to rounding errors or something like that?
-            updated_at_max = updated_at_min + datetime.timedelta(days=date_window_size)
+            # If last sync was interrupted, set updated_at_max to
+            # updated_at_max bookmarked in the interrupted sync.
+            # This will make sure that records with lower id than since_id
+            # which got updated later won't be missed
+            updated_at_max = last_sync_interrupted_at or updated_at_min + \
+                datetime.timedelta(days=date_window_size)
+            last_sync_interrupted_at = None
+
             if updated_at_max > stop_time:
                 updated_at_max = stop_time
             while True:
@@ -267,6 +279,8 @@ class Stream():
                     # window and can move forward. Also remove the since_id because we want to
                     # restart at 1.
                     Context.state.get('bookmarks', {}).get(self.name, {}).pop('since_id', None)
+                    Context.state.get('bookmarks', {}).get(
+                        self.name, {}).pop('updated_at_max', None)
                     self.update_bookmark(utils.strftime(updated_at_max))
                     break
 
@@ -278,8 +292,9 @@ class Stream():
                         objects[-1].id, max([o.id for o in objects])))
                 since_id = objects[-1].id
 
-                # Put since_id into the state.
+                # Put since_id and updated_at_max into the state.
                 self.update_bookmark(since_id, bookmark_key='since_id')
+                self.update_bookmark(utils.strftime(updated_at_max), bookmark_key='updated_at_max')
 
             updated_at_min = updated_at_max
         bookmark = max(min(stop_time,

--- a/tests/unittests/test_updated_bookmark.py
+++ b/tests/unittests/test_updated_bookmark.py
@@ -19,8 +19,8 @@ class Customer():
         return {"id": self.id, "updated_at": self.updated_at}
 
 
-CUSTOMER_1 = Customer(2, "2021-08-11T01:57:05-04:00")
-CUSTOMER_2 = Customer(3, "2021-08-12T01:57:05-04:00")
+CUSTOMER_1 = Customer(20, "2021-08-11T01:57:05-04:00")
+CUSTOMER_2 = Customer(30, "2021-08-12T01:57:05-04:00")
 
 NOW_TIME = '2021-08-16T01:56:05-04:00'
 class TestUpdateBookmark(unittest.TestCase):
@@ -37,3 +37,53 @@ class TestUpdateBookmark(unittest.TestCase):
         customers = list(CUSTOMER_OBJECT.get_objects())
         # Verify that the min-max evaluation returns correct results and provided in the update_bookmark()
         mock_update_bookmark.assert_called_with(strftime(strptime_to_utc(NOW_TIME) - datetime.timedelta(DATE_WINDOW_SIZE)))
+
+
+    @mock.patch("tap_shopify.streams.base.Stream.call_api")
+    @mock.patch("tap_shopify.streams.base.Stream.get_bookmark", return_value=strptime_to_utc('2021-08-11T01:55:05-04:00'))
+    @mock.patch("tap_shopify.streams.base.Stream.update_bookmark")
+    @mock.patch("tap_shopify.streams.base.Stream.get_query_params")
+    @mock.patch("singer.utils.now", return_value=strptime_to_utc(NOW_TIME))
+    def test_since_id_and_updated_at_max_deleted(self, mock_now, mock_get_query_params, mock_update_bookmark, mock_get_bookmark, mock_call_api):
+        """Verify after successful sync since_id and updated_at_max keys are deleted from the state"""
+        mock_call_api.return_value = [CUSTOMER_1, CUSTOMER_2]
+        Context.state = {"bookmarks": {
+            "currently_sync_stream": 'customers',
+            "customers": {
+                "updated_at": "2021-03-27T00:00:00.000000Z",
+                "since_id": 15,
+                "updated_at_max": "2021-04-26T00:00:00.000000Z"}}}
+
+        customers = list(CUSTOMER_OBJECT.get_objects())
+
+        self.assertNotIn("since_id", Context.state["bookmarks"]["customers"])
+        self.assertNotIn("updated_at_max", Context.state["bookmarks"]["customers"])
+
+    @mock.patch("tap_shopify.streams.base.Stream.call_api")
+    @mock.patch("tap_shopify.streams.base.Stream.get_bookmark", return_value=strptime_to_utc('2021-08-11T01:55:05-04:00'))
+    @mock.patch("tap_shopify.streams.base.Stream.update_bookmark")
+    @mock.patch("tap_shopify.streams.base.Stream.get_query_params")
+    @mock.patch("singer.utils.now", return_value=strptime_to_utc(NOW_TIME))
+    def test_interrupted_sync(self, mock_now, mock_get_query_params, mock_update_bookmark, mock_get_bookmark, mock_call_api):
+        """Verify if sync is interrrupted twice in a row then since_id and updated_at_max keys are not deleted from the state"""
+        mock_call_api.side_effect = Exception("Dummy exception...")
+        Context.state = {"bookmarks": {
+            "currently_sync_stream": 'customers',
+            "customers": {
+                "updated_at": "2021-03-27T00:00:00.000000Z",
+                "since_id": 15,
+                "updated_at_max": "2021-04-26T00:00:00.000000Z"}}}
+
+        try:
+            customers = list(CUSTOMER_OBJECT.get_objects())
+        except:
+            pass
+
+        # Verify keys exist
+        self.assertIn("since_id", Context.state["bookmarks"]["customers"])
+        self.assertIn("updated_at_max", Context.state["bookmarks"]["customers"])
+
+        # Verify key values are as expected
+        self.assertEqual(Context.state["bookmarks"]["customers"]['since_id'], 15)
+        self.assertEqual(Context.state["bookmarks"]["customers"]['updated_at_max'], "2021-04-26T00:00:00.000000Z")
+

--- a/tests/unittests/test_updated_bookmark.py
+++ b/tests/unittests/test_updated_bookmark.py
@@ -19,34 +19,32 @@ class Customer():
         return {"id": self.id, "updated_at": self.updated_at}
 
 
+class DummyShopifyError(Exception):
+    def __init__(self, error, msg=''):
+        super().__init__('{}\n{}'.format(error.__class__.__name__, msg))
+
+
 CUSTOMER_1 = Customer(20, "2021-08-11T01:57:05-04:00")
 CUSTOMER_2 = Customer(30, "2021-08-12T01:57:05-04:00")
 
 NOW_TIME = '2021-08-16T01:56:05-04:00'
 class TestUpdateBookmark(unittest.TestCase):
 
-    @mock.patch("tap_shopify.streams.base.Stream.call_api")
+    @mock.patch("tap_shopify.streams.base.Stream.call_api", return_value = [CUSTOMER_1, CUSTOMER_2])
     @mock.patch("tap_shopify.streams.base.Stream.get_bookmark", return_value=strptime_to_utc('2021-08-11T01:55:05-04:00'))
     @mock.patch("tap_shopify.streams.base.Stream.update_bookmark")
     @mock.patch("tap_shopify.streams.base.Stream.get_query_params")
     @mock.patch("singer.utils.now", return_value=strptime_to_utc(NOW_TIME))
     def test_update_bookmark(self, mock_now, mock_get_query_params, mock_update_bookmark, mock_get_bookmark, mock_call_api):
         """Verify that the update_bookmark() is called with correct argument"""
-        mock_call_api.return_value = [CUSTOMER_1, CUSTOMER_2]
-
-        customers = list(CUSTOMER_OBJECT.get_objects())
+        list(CUSTOMER_OBJECT.get_objects())
         # Verify that the min-max evaluation returns correct results and provided in the update_bookmark()
         mock_update_bookmark.assert_called_with(strftime(strptime_to_utc(NOW_TIME) - datetime.timedelta(DATE_WINDOW_SIZE)))
 
-
-    @mock.patch("tap_shopify.streams.base.Stream.call_api")
-    @mock.patch("tap_shopify.streams.base.Stream.get_bookmark", return_value=strptime_to_utc('2021-08-11T01:55:05-04:00'))
-    @mock.patch("tap_shopify.streams.base.Stream.update_bookmark")
-    @mock.patch("tap_shopify.streams.base.Stream.get_query_params")
+    @mock.patch("tap_shopify.streams.base.Stream.call_api", return_value=[CUSTOMER_1, CUSTOMER_2])
     @mock.patch("singer.utils.now", return_value=strptime_to_utc(NOW_TIME))
-    def test_since_id_and_updated_at_max_deleted(self, mock_now, mock_get_query_params, mock_update_bookmark, mock_get_bookmark, mock_call_api):
+    def test_since_id_and_updated_at_max_deleted(self, mock_now, mock_call_api):
         """Verify after successful sync since_id and updated_at_max keys are deleted from the state"""
-        mock_call_api.return_value = [CUSTOMER_1, CUSTOMER_2]
         Context.state = {"bookmarks": {
             "currently_sync_stream": 'customers',
             "customers": {
@@ -54,19 +52,17 @@ class TestUpdateBookmark(unittest.TestCase):
                 "since_id": 15,
                 "updated_at_max": "2021-04-26T00:00:00.000000Z"}}}
 
-        customers = list(CUSTOMER_OBJECT.get_objects())
+        list(CUSTOMER_OBJECT.get_objects())
 
+        # Verify keys
+        self.assertIn("updated_at", Context.state["bookmarks"]["customers"])
         self.assertNotIn("since_id", Context.state["bookmarks"]["customers"])
         self.assertNotIn("updated_at_max", Context.state["bookmarks"]["customers"])
 
-    @mock.patch("tap_shopify.streams.base.Stream.call_api")
-    @mock.patch("tap_shopify.streams.base.Stream.get_bookmark", return_value=strptime_to_utc('2021-08-11T01:55:05-04:00'))
-    @mock.patch("tap_shopify.streams.base.Stream.update_bookmark")
-    @mock.patch("tap_shopify.streams.base.Stream.get_query_params")
+    @mock.patch("tap_shopify.streams.base.Stream.call_api", side_effect=DummyShopifyError("Dummy Shopify exception..."))
     @mock.patch("singer.utils.now", return_value=strptime_to_utc(NOW_TIME))
-    def test_interrupted_sync(self, mock_now, mock_get_query_params, mock_update_bookmark, mock_get_bookmark, mock_call_api):
+    def test_interrupted_sync(self, mock_now, mock_call_api):
         """Verify if sync is interrrupted twice in a row then since_id and updated_at_max keys are not deleted from the state"""
-        mock_call_api.side_effect = Exception("Dummy exception...")
         Context.state = {"bookmarks": {
             "currently_sync_stream": 'customers',
             "customers": {
@@ -74,16 +70,14 @@ class TestUpdateBookmark(unittest.TestCase):
                 "since_id": 15,
                 "updated_at_max": "2021-04-26T00:00:00.000000Z"}}}
 
-        try:
-            customers = list(CUSTOMER_OBJECT.get_objects())
-        except:
-            pass
+        with self.assertRaises(DummyShopifyError):
+            list(CUSTOMER_OBJECT.get_objects())
 
         # Verify keys exist
         self.assertIn("since_id", Context.state["bookmarks"]["customers"])
         self.assertIn("updated_at_max", Context.state["bookmarks"]["customers"])
 
-        # Verify key values are as expected
+        # Verify bookmark key values are as expected
         self.assertEqual(Context.state["bookmarks"]["customers"]['since_id'], 15)
         self.assertEqual(Context.state["bookmarks"]["customers"]['updated_at_max'], "2021-04-26T00:00:00.000000Z")
 


### PR DESCRIPTION
# Description of change

Consider we have following records to sync from the source,

(order_id |  replication_key): 

- (1, 101),
- (2, 102), 
- (3, 103), 
- (4, 104), 
- (5, 105), 
- (6, 106), 
- (7, 107), 
- (8, 108), 
- (7, 109), (9, 109),  --> **order_id#7** gets updated here
- (10, 110)  

Before sync starts,
- Sync starts at: 110
- Window size: 5
- Bookmark=100
- First window: 100-105

# Scenario
- Sync interrupted at: since_id=8 (replication_key=108)
- Next sync starts at: 115
- Record updated before next sync: order_id=7 (replication_key=109)

On completion of next sync,

- since_id = 7
- Windows: (100-105), (105-110), (110-115)
- Bookmark = min(max_bookmark_value, stop_time) = 110

In this scenario, on resuming sync updated record id#7 with (replication_key=109) will not sync with current implementation.

# Solution:
Add `updated_at_max` value along with `since_id` and on resuming interrupted sync set window between (bookmark, updated_at_max). 

- Sync interrupted at: since_id=8 (replication_key=108)
- Next sync starts at: 115
- Record updated before next sync: order_id=7 (replication_key=109)

On completion of next sync,

- since_id = 1  --> pop() the `since_id=8` from the bookmark
- Starting window: (105-108), (108-113), (113-115)
- Bookmark = min(max_bookmark_value, stop_time) = 110

This solution will make sure on resuming the interrupted sync, record id#7 (replication_key=109) will be synced.

# QA steps
 - [x] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch
