### PR TITLE
Revert "Bump version, update changelog"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,5 @@
 # Changelog
 
-## 1.7.5
-  * Dependabot update [#167](https://github.com/singer-io/tap-shopify/pull/167)
-
 ## 1.7.4
   * Add backoff for IncompleteRead [#144](https://github.com/singer-io/tap-shopify/pull/144)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-shopify",
-    version="1.7.5",
+    version="1.7.4",
     description="Singer.io tap for extracting Shopify data",
     author="Stitch",
     url="http://github.com/singer-io/tap-shopify",


### PR DESCRIPTION
This reverts commit 1debdba753d0e80617b40c9680ecb07c7048f290.

# Description of change
This PR reverts a commit that was intended for a PR from dependabot - but it turns out that PR doesn't exist. And the script I was using to manage these dependabot PRs was supposed to push to a branch, and somehow this was on master

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks
- None. Just undoing this change before it can get deployed
# Rollback steps
 - revert this branch
