### PR TITLE
TDL-23255 Upgrade Shopify API to 2023_04

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ jobs:
           path: htmlcov
   run_integration_tests:
     executor: docker-executor
-    parallelism: 5
+    parallelism: 3
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
             stitch-validate-json tap_shopify/schemas/*.json
   run_unit_tests:
     executor: docker-executor
-    steps:   
+    steps:
       - checkout
       - attach_workspace:
           at: /usr/local/share/virtualenvs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ jobs:
           path: htmlcov
   run_integration_tests:
     executor: docker-executor
-    parallelism: 3
+    parallelism: 2
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,7 @@ jobs:
           path: htmlcov
       - run:
           name: 'Integration Tests'
+          parallelism: 5
           command: |
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
             source dev_env.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.8.0
+  * Updates the Shopify SDK to 12.3.0
+  * Updates API version used to 2023_04
+  * Adds and removes fields per Shopify API changelog for versions 2022_10, 2023_01, 2023_04 [#178](https://github.com/singer-io/tap-shopify/pull/178)
+
 ## 1.7.6
   * Add backoff for 404 error code [#159](https://github.com/singer-io/tap-shopify/pull/159)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[metadata]
-description-file = README.md

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-shopify",
-    version="1.7.6",
+    version="1.8.0",
     description="Singer.io tap for extracting Shopify data",
     author="Stitch",
     url="http://github.com/singer-io/tap-shopify",

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     python_requires='>=3.5.2',
     py_modules=["tap_shopify"],
     install_requires=[
-        "ShopifyAPI==12.0.1",
+        "ShopifyAPI==12.3.0",
         "singer-python==5.12.1",
     ],
     extras_require={

--- a/tap_shopify/__init__.py
+++ b/tap_shopify/__init__.py
@@ -25,7 +25,7 @@ SDC_KEYS = {'id': 'integer', 'name': 'string', 'myshopify_domain': 'string'}
 def initialize_shopify_client():
     api_key = Context.config['api_key']
     shop = Context.config['shop']
-    version = '2022-07'
+    version = '2023-04'
     session = shopify.Session(shop, version, api_key)
     shopify.ShopifyResource.activate_session(session)
 

--- a/tap_shopify/schemas/definitions.json
+++ b/tap_shopify/schemas/definitions.json
@@ -1282,6 +1282,12 @@
           "boolean"
         ]
       },
+      "fulfillment_service": {
+        "type": [
+          "null",
+          "string"
+        ]
+      },
       "variant_inventory_management": {
         "type": [
           "null",

--- a/tap_shopify/schemas/definitions.json
+++ b/tap_shopify/schemas/definitions.json
@@ -1282,12 +1282,6 @@
           "boolean"
         ]
       },
-      "fulfillment_service": {
-        "type": [
-          "null",
-          "string"
-        ]
-      },
       "variant_inventory_management": {
         "type": [
           "null",

--- a/tap_shopify/schemas/orders.json
+++ b/tap_shopify/schemas/orders.json
@@ -1223,94 +1223,58 @@
       ]
     },
     "merchant_of_record_app_id": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "current_total_additional_fees_set": {
-      "type": [
-        "null",
-        "object"
-      ],
-      "properties": [
+      "type": ["null", "object"],
+      "properties": {
         "presentment_money": {
-          "type": [
-            "null",
-            "object"
-          ],
-          "properties": [
+          "type": ["null", "object"],
+          "properties": {
             "amount": {
-              "type": [
-                "null",
-                "string"
-              ],
-              "format": "singer.decimal"
-            },
+              "type": ["null", "string"],
+              "format": "singer.decimal"},
             "currency": {
-              "type": [
-                "null",
-                "string"
-              ],
-            },
-            "shop_money": {
-              "type": [
-                "null",
-                "string"
-              ],
-              "format": "singer.decimal"
-            },
+              "type": ["null", "string"]}
+          }
+        },
+        "shop_money": {
+          "type": ["null", "object"],
+          "properties": {
+            "amount": {
+              "type": ["null", "string"],
+              "format": "singer.decimal"},
             "currency": {
-              "type": [
-                "null",
-                "string"
-              ],
-            }
-          ]
+              "type": ["null", "string"]}
+          }
         }
-      ]
+      }
     },
     "original_total_additional_fees_set": {
-      "type": [
-        "null",
-        "object"
-      ],
-      "properties": [
+      "type": ["null", "object"],
+      "properties": {
         "presentment_money": {
-          "type": [
-            "null",
-            "object"
-          ],
-          "properties": [
+          "type": ["null", "object"],
+          "properties": {
             "amount": {
-              "type": [
-                "null",
-                "string"
-              ],
-              "format": "singer.decimal"
-            },
+              "type": ["null", "string"],
+              "format": "singer.decimal"},
             "currency": {
-              "type": [
-                "null",
-                "string"
-              ],
-            },
-            "shop_money": {
-              "type": [
-                "null",
-                "string"
-              ],
-              "format": "singer.decimal"
-            },
-            "currency": {
-              "type": [
-                "null",
-                "string"
-              ],
+              "type": ["null", "string"]
             }
-          ]
+          }
+        },
+        "shop_money": {
+          "type": ["null", "object"],
+          "properties": {
+            "amount": {
+              "type": ["null", "string"],
+              "format": "singer.decimal"},
+            "currency": {
+              "type": ["null", "string"]}
+          }
         }
-      ]
+      }
     }
   },
   "type": "object"

--- a/tap_shopify/schemas/orders.json
+++ b/tap_shopify/schemas/orders.json
@@ -574,13 +574,6 @@
         "object"
       ]
     },
-    "total_price_usd": {
-      "type": [
-        "null",
-        "string"
-      ],
-      "format": "singer.decimal"
-    },
     "closed_at": {
       "type": [
         "null",

--- a/tap_shopify/schemas/orders.json
+++ b/tap_shopify/schemas/orders.json
@@ -1271,7 +1271,13 @@
         "null",
         "boolean"
       ]
-    }
+    },
+    "merchant_of_record_app_id": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
   },
   "type": "object"
 }

--- a/tap_shopify/schemas/orders.json
+++ b/tap_shopify/schemas/orders.json
@@ -1227,6 +1227,90 @@
         "null",
         "integer"
       ]
+    },
+    "current_total_additional_fees_set": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": [
+        "presentment_money": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "properties": [
+            "amount": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "singer.decimal"
+            },
+            "currency": {
+              "type": [
+                "null",
+                "string"
+              ],
+            },
+            "shop_money": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "singer.decimal"
+            },
+            "currency": {
+              "type": [
+                "null",
+                "string"
+              ],
+            }
+          ]
+        }
+      ]
+    },
+    "original_total_additional_fees_set": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": [
+        "presentment_money": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "properties": [
+            "amount": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "singer.decimal"
+            },
+            "currency": {
+              "type": [
+                "null",
+                "string"
+              ],
+            },
+            "shop_money": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "singer.decimal"
+            },
+            "currency": {
+              "type": [
+                "null",
+                "string"
+              ],
+            }
+          ]
+        }
+      ]
     }
   },
   "type": "object"

--- a/tap_shopify/schemas/orders.json
+++ b/tap_shopify/schemas/orders.json
@@ -58,12 +58,6 @@
     "line_items": {
       "$ref": "definitions.json#/line_items"
     },
-    "processing_method": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
     "order_number": {
       "type": [
         "null",
@@ -413,44 +407,6 @@
         "string"
       ],
       "format": "singer.decimal"
-    },
-    "payment_details": {
-      "properties": {
-        "avs_result_code": {
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "credit_card_company": {
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "cvv_result_code": {
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "credit_card_bin": {
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "credit_card_number": {
-          "type": [
-            "null",
-            "string"
-          ]
-        }
-      },
-      "type": [
-        "null",
-        "object"
-      ]
     },
     "number": {
       "type": [
@@ -978,12 +934,6 @@
       "type": [
         "null",
         "integer"
-      ]
-    },
-    "gateway": {
-      "type": [
-        "null",
-        "string"
       ]
     },
     "cart_token": {

--- a/tap_shopify/schemas/orders.json
+++ b/tap_shopify/schemas/orders.json
@@ -1277,7 +1277,7 @@
         "null",
         "integer"
       ]
-    },
+    }
   },
   "type": "object"
 }

--- a/tap_shopify/schemas/transactions.json
+++ b/tap_shopify/schemas/transactions.json
@@ -232,6 +232,48 @@
         "null",
         "string"
       ]
+    },
+    "total_unsettled_set": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": [
+        "presentment_money": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "properties": [
+            "amount": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "singer.decimal"
+            },
+            "currency": {
+              "type": [
+                "null",
+                "string"
+              ],
+            },
+            "shop_money": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "singer.decimal"
+            },
+            "currency": {
+              "type": [
+                "null",
+                "string"
+              ],
+            }
+          ]
+        }
+      ]
     }
   },
   "type": "object"

--- a/tap_shopify/schemas/transactions.json
+++ b/tap_shopify/schemas/transactions.json
@@ -111,7 +111,31 @@
             "string"
           ]
         },
+        "credit_card_expiration_month": {
+          "type": [
+            "null",
+            "integer"
+          ]
+        },
+        "credit_card_expiration_year": {
+          "type": [
+            "null",
+            "integer"
+          ]
+        },
+        "credit_card_name": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
         "credit_card_number": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "credit_card_wallet": {
           "type": [
             "null",
             "string"

--- a/tap_shopify/schemas/transactions.json
+++ b/tap_shopify/schemas/transactions.json
@@ -226,6 +226,12 @@
           ]
         }
       }
+    },
+    "payment_id": {
+      "type": [
+        "null",
+        "string"
+      ]
     }
   },
   "type": "object"

--- a/tap_shopify/schemas/transactions.json
+++ b/tap_shopify/schemas/transactions.json
@@ -234,46 +234,30 @@
       ]
     },
     "total_unsettled_set": {
-      "type": [
-        "null",
-        "object"
-      ],
-      "properties": [
+      "type": ["null", "object"],
+      "properties": {
         "presentment_money": {
-          "type": [
-            "null",
-            "object"
-          ],
-          "properties": [
+          "type": ["null", "object"],
+          "properties": {
             "amount": {
-              "type": [
-                "null",
-                "string"
-              ],
-              "format": "singer.decimal"
-            },
+              "type": ["null", "string"],
+              "format": "singer.decimal"},
             "currency": {
-              "type": [
-                "null",
-                "string"
-              ],
-            },
-            "shop_money": {
-              "type": [
-                "null",
-                "string"
-              ],
-              "format": "singer.decimal"
-            },
-            "currency": {
-              "type": [
-                "null",
-                "string"
-              ],
+              "type": ["null", "string"]
             }
-          ]
+          }
+        },
+        "shop_money": {
+          "type": ["null", "object"],
+          "properties": {
+            "amount": {
+              "type": ["null", "string"],
+              "format": "singer.decimal"},
+            "currency": {
+              "type": ["null", "string"]}
+          }
         }
-      ]
+      }
     }
   },
   "type": "object"

--- a/tests/test_bookmarks_updated.py
+++ b/tests/test_bookmarks_updated.py
@@ -13,7 +13,7 @@ class BookmarkTest(BaseTapTest):
     """Test tap sets a bookmark and respects it for the next sync of a stream"""
     @staticmethod
     def name():
-        return "tap_tester_shopify_bookmark_test"
+        return "tap_tester_shopify_bookmark_update_test"
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
# Description of change
- Updates the Shopify SDK to 12.3.0
- Updates API version used to 2023_04
- Incorporates changes listed below to schemas
  - [2022_10 changes](https://shopify.dev/docs/api/release-notes/2022-10):
    - added merchant_of_record_app_id field to orders stream
    - removed total_price_usd field from orders stream
  - [2023_01 changes](https://shopify.dev/docs/api/release-notes/2023-01):
    - added payment_details field to transactions stream
    - added payment_id field to transactions stream
  - [2023_04 changes](https://shopify.dev/docs/api/release-notes/2023-04):
    - removed gateway field from orders stream
    - removed payment_details object from orders stream
    - removed processing_method field from orders stream
    - added total_unsettled_set object to transactions stream
    - added current_total_additional_fees_set object to orders stream
    - added original_total_additional_fees_set object to orders stream
- Version bump & changelog

# QA steps
 - [x] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks
Should not be merged without Shopify app update

# Rollback steps
 - revert this branch
