### PR TITLE
Fix transactions receipt logic

### DIFF
--- a/tap_shopify/schemas/definitions.json
+++ b/tap_shopify/schemas/definitions.json
@@ -402,18 +402,11 @@
         ]
       },
       "accepts_marketing_updated_at": {
-        "anyOf": [
-          {
-            "type": "string" ,
-            "format": "date-time"
-          },
-          {
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ]
+        "type": [
+          "null",
+          "string"
+        ],
+        "format": "date-time"
       },
       "created_at": {
         "type": [

--- a/tap_shopify/streams/base.py
+++ b/tap_shopify/streams/base.py
@@ -2,6 +2,7 @@ import datetime
 import functools
 import math
 import sys
+import http
 
 import backoff
 import pyactiveresource
@@ -54,7 +55,8 @@ def shopify_error_handling(fnc):
     @backoff.on_exception(backoff.expo,
                           (pyactiveresource.connection.ServerError,
                            pyactiveresource.formats.Error,
-                           simplejson.scanner.JSONDecodeError),
+                           simplejson.scanner.JSONDecodeError,
+                           http.client.HTTPException),
                           giveup=is_not_status_code_fn(range(500, 599)),
                           on_backoff=retry_handler,
                           max_tries=MAX_RETRIES)

--- a/tap_shopify/streams/transactions.py
+++ b/tap_shopify/streams/transactions.py
@@ -89,8 +89,11 @@ class Transactions(Stream):
     def sync(self):
         for transaction in self.get_objects():
             transaction_dict = transaction.to_dict()
-            for field_name in ['token', 'version', 'ack']:
-                canonicalize(transaction_dict, field_name)
-            yield transaction_dict
+            if transaction_dict is not None and transaction_dict['receipt'] is not None:
+                for field_name in ['token', 'version', 'ack']:
+                    canonicalize(transaction_dict, field_name)
+                yield transaction_dict
+            else:
+                continue
 
 Context.stream_objects['transactions'] = Transactions


### PR DESCRIPTION
Transactions stream was failing due to having NoneType `receipt` objects in the transaction dict. Now we will confirm that a receipt exists before trying to call for it.
