### PR TITLE
Upgrade Shopify API to 2024-01

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.10.0
+  * Updates the Shopify SDK to 12.3.0
+  * Updates API version used to 2024-01
+  * Incarporates schema changes [#187](https://github.com/singer-io/tap-shopify/pull/187)
+
 ## 1.9.0
   * Updates to run on python 3.11 [#186](https://github.com/singer-io/tap-shopify/pull/186)
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     python_requires='>=3.5.2',
     py_modules=["tap_shopify"],
     install_requires=[
-        "ShopifyAPI==12.3.0",
+        "ShopifyAPI==12.4.0",
         "singer-python==6.0.0",
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-shopify",
-    version="1.9.0",
+    version="1.10.0",
     description="Singer.io tap for extracting Shopify data",
     author="Stitch",
     url="http://github.com/singer-io/tap-shopify",

--- a/tap_shopify/__init__.py
+++ b/tap_shopify/__init__.py
@@ -25,7 +25,7 @@ SDC_KEYS = {'id': 'integer', 'name': 'string', 'myshopify_domain': 'string'}
 def initialize_shopify_client():
     api_key = Context.config['api_key']
     shop = Context.config['shop']
-    version = '2023-04'
+    version = '2024-01'
     session = shopify.Session(shop, version, api_key)
     shopify.ShopifyResource.activate_session(session)
 

--- a/tap_shopify/schemas/definitions.json
+++ b/tap_shopify/schemas/definitions.json
@@ -81,12 +81,6 @@
           "string"
         ]
       },
-      "currency": {
-        "type": [
-          "null",
-          "string"
-        ]
-      },
       "email": {
         "type": [
           "null",
@@ -410,26 +404,6 @@
           "integer"
         ]
       },
-      "accepts_marketing": {
-        "type": [
-          "null",
-          "boolean"
-        ]
-      },
-      "accepts_marketing_updated_at": {
-        "anyOf": [
-          {
-            "type": "string" ,
-            "format": "date-time"
-          },
-          {
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ]
-      },
       "created_at": {
         "type": [
           "null",
@@ -448,12 +422,6 @@
             "string"
           ]
         }
-      },
-      "marketing_opt_in_level": {
-        "type": [
-          "null",
-          "string"
-        ]
       },
       "email_marketing_consent": {
         "type": [

--- a/tap_shopify/schemas/orders.json
+++ b/tap_shopify/schemas/orders.json
@@ -70,6 +70,18 @@
         "boolean"
       ]
     },
+    "taxExempt": {
+      "type": [
+        "null",
+        "boolean"
+      ]      
+    },
+    "poNumber": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "total_discounts": {
       "type": [
         "null",

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -96,7 +96,8 @@ class AllFieldsTest(BaseTapTest):
                     # Documentation: https://shopify.dev/api/admin-rest/2021-10/resources/order#resource_object
                     # https://jira.talendforge.org/browse/TDL-15985
                     # total_price_usd showing up in syncd records Sep 2023, still missing from docs
-                    bad_schema_fields = {'order_adjustments', 'taxExempt', 'poNumber'}
-                    expected_all_keys = expected_all_keys - bad_schema_fields
+                    bad_schema_fields = {'order_adjustments'}
+                    missing_fields = {'taxExempt', 'poNumber'}
+                    expected_all_keys = expected_all_keys - bad_schema_fields - missing_fields
 
                 self.assertSetEqual(expected_all_keys, actual_all_keys)

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -97,6 +97,8 @@ class AllFieldsTest(BaseTapTest):
                     # https://jira.talendforge.org/browse/TDL-15985
                     # total_price_usd showing up in syncd records Sep 2023, still missing from docs
                     bad_schema_fields = {'order_adjustments'}
+                    # missing data for 'taxExempt' and 'poNumber' in 'orders' stream
+                    # https://jira.talendforge.org/browse/TDL-25173
                     missing_fields = {'taxExempt', 'poNumber'}
                     expected_all_keys = expected_all_keys - bad_schema_fields - missing_fields
 

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -96,7 +96,7 @@ class AllFieldsTest(BaseTapTest):
                     # Documentation: https://shopify.dev/api/admin-rest/2021-10/resources/order#resource_object
                     # https://jira.talendforge.org/browse/TDL-15985
                     # total_price_usd showing up in syncd records Sep 2023, still missing from docs
-                    bad_schema_fields = {'order_adjustments'}
+                    bad_schema_fields = {'order_adjustments', 'taxExempt', 'poNumber'}
                     expected_all_keys = expected_all_keys - bad_schema_fields
 
                 self.assertSetEqual(expected_all_keys, actual_all_keys)


### PR DESCRIPTION
# Description of change

- Updates the Shopify SDK to 12.3.0
- Updates API version used to 2023_04
- Incorporates schema changes
- Version bump & changelog
(Fixing the integration tests in different PR)

# QA steps
 - [x] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch
