### PR TITLE
Add `payment_details.payment_method_name` to transactions.json

### DIFF
--- a/tap_shopify/schemas/transactions.json
+++ b/tap_shopify/schemas/transactions.json
@@ -146,6 +146,12 @@
             "null",
             "string"
           ]
+        },
+        "payment_method_name": {
+          "type": [
+            "null",
+            "string"
+          ]
         }
       },
       "type": [


### PR DESCRIPTION
# Description of change
`payment_details.payment_method_name` was added to the transactions spec in Shopify Admin API v2024-01 
https://shopify.dev/docs/api/admin-rest/2024-01/resources/transaction#resource-object

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch
