### PR TITLE
Deprecation Warning for products, inventory_items, and product metafields 

### DIFF
--- a/tap_shopify/__init__.py
+++ b/tap_shopify/__init__.py
@@ -13,7 +13,7 @@ from singer import utils
 from singer import metadata
 from singer import Transformer
 from tap_shopify.context import Context
-from tap_shopify.exceptions import ShopifyError
+from tap_shopify.exceptions import ShopifyError, SHopifyDeprecationError
 from tap_shopify.streams.base import shopify_error_handling, get_request_timeout
 import tap_shopify.streams # Load stream objects into Context
 
@@ -30,13 +30,13 @@ def raise_warning():
 
     if SELECTED_DEPRECATED_STREAMS:
         if today_utc > cutoff_date:
-            raise Exception(
+            raise SHopifyDeprecationError(
                 f"The {SELECTED_DEPRECATED_STREAMS} streams are no longer supported after 31st January 2025. "
                 "Please upgrade to the latest version of tap-shopify, which supports GraphQL endpoints for these streams."
             )
         else:
             days_left = (cutoff_date - today_utc).days
-            raise Exception(
+            raise SHopifyDeprecationError(
                 f"WARNING: The {SELECTED_DEPRECATED_STREAMS} streams are deprecated and will no longer be supported "
                 f"after 31st January 2025, ({days_left} days left). Please upgrade to the latest version of tap-shopify, "
                 "which supports GraphQL endpoints for these streams."
@@ -248,6 +248,8 @@ def main():
             msg = body.get('errors')
         finally:
             raise ShopifyError(exc, msg) from exc
+    except SHopifyDeprecationError as exc:
+        raise SHopifyDeprecationError(exc) from None
     except Exception as exc:
         raise ShopifyError(exc) from exc
 

--- a/tap_shopify/__init__.py
+++ b/tap_shopify/__init__.py
@@ -160,7 +160,8 @@ def sync():
     for catalog_entry in Context.catalog['streams']:
         stream_id = catalog_entry['tap_stream_id']
         if stream_id in DISABLED_STREAMS:
-                continue
+            LOGGER.critical('Deprecated stream: %s, please upgrade to latest version', stream_id)
+            continue
         stream = Context.stream_objects[stream_id]()
 
         if not Context.is_selected(stream_id):

--- a/tap_shopify/__init__.py
+++ b/tap_shopify/__init__.py
@@ -18,6 +18,8 @@ from tap_shopify.streams.base import shopify_error_handling, get_request_timeout
 import tap_shopify.streams # Load stream objects into Context
 
 REQUIRED_CONFIG_KEYS = ["shop", "api_key"]
+DISABLED_STREAMS = ["products", "inventory_items"]
+
 LOGGER = singer.get_logger()
 SDC_KEYS = {'id': 'integer', 'name': 'string', 'myshopify_domain': 'string'}
 
@@ -146,6 +148,8 @@ def sync():
     # Emit all schemas first so we have them for child streams
     for stream in Context.catalog["streams"]:
         if Context.is_selected(stream["tap_stream_id"]):
+            if stream["tap_stream_id"] in DISABLED_STREAMS:
+                continue
             singer.write_schema(stream["tap_stream_id"],
                                 stream["schema"],
                                 stream["key_properties"],
@@ -155,6 +159,8 @@ def sync():
     # Loop over streams in catalog
     for catalog_entry in Context.catalog['streams']:
         stream_id = catalog_entry['tap_stream_id']
+        if stream_id in DISABLED_STREAMS:
+                continue
         stream = Context.stream_objects[stream_id]()
 
         if not Context.is_selected(stream_id):

--- a/tap_shopify/exceptions.py
+++ b/tap_shopify/exceptions.py
@@ -2,5 +2,5 @@ class ShopifyError(Exception):
     def __init__(self, error, msg=''):
         super().__init__('{}\n{}'.format(error.__class__.__name__, msg))
 
-class SHopifyDeprecationError(Exception):
+class ShopifyDeprecationError(Exception):
     pass

--- a/tap_shopify/exceptions.py
+++ b/tap_shopify/exceptions.py
@@ -1,3 +1,6 @@
 class ShopifyError(Exception):
     def __init__(self, error, msg=''):
         super().__init__('{}\n{}'.format(error.__class__.__name__, msg))
+
+class SHopifyDeprecationError(Exception):
+    pass

--- a/tap_shopify/streams/metafields.py
+++ b/tap_shopify/streams/metafields.py
@@ -11,7 +11,7 @@ from tap_shopify.streams.base import (Stream,
 LOGGER = singer.get_logger()
 
 def get_selected_parents():
-    for parent_stream in ['orders', 'customers', 'custom_collections']:
+    for parent_stream in ['orders', 'customers', 'products', 'custom_collections']:
         if Context.is_selected(parent_stream):
             yield Context.stream_objects[parent_stream]()
 

--- a/tap_shopify/streams/metafields.py
+++ b/tap_shopify/streams/metafields.py
@@ -11,7 +11,7 @@ from tap_shopify.streams.base import (Stream,
 LOGGER = singer.get_logger()
 
 def get_selected_parents():
-    for parent_stream in ['orders', 'customers', 'products', 'custom_collections']:
+    for parent_stream in ['orders', 'customers', 'custom_collections']:
         if Context.is_selected(parent_stream):
             yield Context.stream_objects[parent_stream]()
 


### PR DESCRIPTION
# Description of change
This PR introduces a mechanism to warn users about the deprecation of the products and variants streams in tap-shopify. Shopify is sunsetting the REST API endpoints for these streams, and they will no longer be supported after 31st January 2025. Users are required to upgrade to the latest version of tap-shopify, which uses GraphQL-based endpoints for these streams.

## Changes Introduced:
### Deprecation Warning:
If the products or variants streams are selected, a deprecation warning is raised before the cutoff date (31st January 2025).

- The warning includes:
        - Stream name(s).
        - Cutoff date.
        - Remaining days until deprecation.
        - Instructions to upgrade to the latest version.

### Custom Exception:

-  Introduced a ShopifyDeprecationError to provide clear, actionable error messages for deprecated streams.
- The exception message varies based on whether the current date is before or after the cutoff date:
> **Before 31st January 2025**: Displays a warning with the number of days left.
> **After 31st January 2025**: Displays an error stating the streams are no longer supported.

## Example Behavior:

1. Before 31st January 2025:

If the user selects the products stream:
```
tap_shopify.exceptions.ShopifyDeprecationError: WARNING: The ['products'] are deprecated and will no longer be supported after 31st January 2025, (4 days left). Please upgrade to the latest version of tap-shopify, which supports GraphQL endpoints for these streams.
```

2. After 31st January 2025:

If the user selects the products stream:
```
tap_shopify.exceptions.ShopifyDeprecationError: The ['products'] are no longer supported after 31st January 2025. Please upgrade to the latest version of tap-shopify, which supports GraphQL endpoints for these streams.
```

# Rollback steps
 - revert this branch
