### PR TITLE
Update bookmark logic for transactions and order_refunds for older tap version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
           name: 'pylint'
           command: |
             source /usr/local/share/virtualenvs/tap-shopify/bin/activate
-            pylint tap_shopify -d missing-docstring,too-many-branches,consider-using-f-string,consider-using-generator,consider-using-dict-items,unnecessary-dunder-call,duplicate-code
+            pylint tap_shopify -d missing-docstring,too-many-branches,consider-using-f-string,consider-using-generator,consider-using-dict-items,unnecessary-dunder-call,duplicate-code,global-statement
   json_validator:
     executor: docker-executor
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.12.0
+  * Update bookmark logic for transactions and order_refunds stream [#198](https://github.com/singer-io/tap-shopify/pull/198)
+
 ## 1.11.0
   * Deprecate the streams for the older version. [#196](https://github.com/singer-io/tap-shopify/pull/196)
   * Deprecated streams - products, inventory_items, metafields (product)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-shopify",
-    version="1.11.0",
+    version="1.12.0",
     description="Singer.io tap for extracting Shopify data",
     author="Stitch",
     url="http://github.com/singer-io/tap-shopify",

--- a/tap_shopify/__init__.py
+++ b/tap_shopify/__init__.py
@@ -34,8 +34,9 @@ def raise_warning():
 
     if SELECTED_DEPRECATED_STREAMS and TODAY_UTC > CUTOFF_DATE:
         raise ShopifyDeprecationError(
-            f"The {SELECTED_DEPRECATED_STREAMS} stream(s) are no longer supported after 31st March 2025. "
-            "Please upgrade to the latest version of tap-shopify, which supports GraphQL endpoints for these streams."
+            f"The {SELECTED_DEPRECATED_STREAMS} stream(s) are no longer supported after 31st March"
+            " 2025. Please upgrade to the latest version of tap-shopify, which supports GraphQL"
+            "endpoints for these streams."
         )
 
 @shopify_error_handling
@@ -182,8 +183,9 @@ def sync():
             SELECTED_DEPRECATED_STREAMS.append(stream_id)
             if TODAY_UTC > CUTOFF_DATE:
                 LOGGER.critical(
-                    f"The {stream_id} stream is no longer supported. "
-                    "Please upgrade to the latest version of tap-shopify, which supports GraphQL endpoints for this stream."
+                    "The %s stream is no longer supported. Please upgrade to the latest "
+                    "version of tap-shopify, which supports GraphQL endpoints for this stream.",
+                    stream_id
                 )
                 continue
         if stream_id == 'metafields':

--- a/tap_shopify/streams/metafields.py
+++ b/tap_shopify/streams/metafields.py
@@ -1,8 +1,8 @@
 import json
+from datetime import datetime, timezone
 import shopify
 import singer
 from singer import utils
-from datetime import datetime, timezone
 
 from tap_shopify.context import Context
 from tap_shopify.streams.base import (Stream,

--- a/tap_shopify/streams/order_refunds.py
+++ b/tap_shopify/streams/order_refunds.py
@@ -1,5 +1,6 @@
 import shopify
-from singer.utils import strftime, strptime_to_utc
+import singer
+from singer.utils import strptime_to_utc
 from tap_shopify.context import Context
 from tap_shopify.streams.base import (Stream,
                                       shopify_error_handling,
@@ -10,6 +11,7 @@ class OrderRefunds(Stream):
     name = 'order_refunds'
     replication_object = shopify.Refund
     replication_key = 'created_at'
+    parent_stream = None
 
     @shopify_error_handling
     def get_refunds(self, parent_object, since_id):
@@ -24,6 +26,7 @@ class OrderRefunds(Stream):
     def get_objects(self):
         selected_parent = Context.stream_objects['orders']()
         selected_parent.name = "refund_orders"
+        self.parent_stream = selected_parent
 
         # Page through all `orders`, bookmarking at `refund_orders`
         for parent_object in selected_parent.get_objects():
@@ -44,7 +47,6 @@ class OrderRefunds(Stream):
 
     def sync(self):
         bookmark = self.get_bookmark()
-        max_bookmark = bookmark
         for refund in self.get_objects():
             refund_dict = refund.to_dict()
             replication_value = strptime_to_utc(refund_dict[self.replication_key])
@@ -54,10 +56,8 @@ class OrderRefunds(Stream):
                         canonicalize(transaction_dict, field_name)
                 yield refund_dict
 
-            if replication_value > max_bookmark:
-                max_bookmark = replication_value
-
-        self.update_bookmark(strftime(max_bookmark))
-
+        max_bookmark = singer.get_bookmark(
+            Context.state, self.parent_stream.name, self.parent_stream.replication_key)
+        self.update_bookmark(max_bookmark)
 
 Context.stream_objects['order_refunds'] = OrderRefunds

--- a/tap_shopify/streams/transactions.py
+++ b/tap_shopify/streams/transactions.py
@@ -1,6 +1,6 @@
 import shopify
 import singer
-from singer.utils import strftime, strptime_to_utc
+from singer.utils import strptime_to_utc
 from tap_shopify.context import Context
 from tap_shopify.streams.base import (Stream,
                                       shopify_error_handling,
@@ -17,6 +17,7 @@ class Transactions(Stream):
     name = 'transactions'
     replication_key = 'created_at'
     replication_object = shopify.Transaction
+    parent_stream = None
     # Added decorator over functions of shopify SDK
     replication_object.find = shopify_error_handling(replication_object.find)
     # Transactions have no updated_at property. Therefore we have
@@ -59,6 +60,7 @@ class Transactions(Stream):
         # Get transactions, bookmarking at `transaction_orders`
         selected_parent = Context.stream_objects['orders']()
         selected_parent.name = "transaction_orders"
+        self.parent_stream = selected_parent
 
         # Page through all `orders`, bookmarking at `transaction_orders`
         for parent_object in selected_parent.get_objects():
@@ -68,7 +70,6 @@ class Transactions(Stream):
 
     def sync(self):
         bookmark = self.get_bookmark()
-        max_bookmark = bookmark
         for transaction in self.get_objects():
             transaction_dict = transaction.to_dict()
             replication_value = strptime_to_utc(transaction_dict[self.replication_key])
@@ -77,9 +78,8 @@ class Transactions(Stream):
                     canonicalize(transaction_dict, field_name)
                 yield transaction_dict
 
-            if replication_value > max_bookmark:
-                max_bookmark = replication_value
-
-        self.update_bookmark(strftime(max_bookmark))
+        max_bookmark = singer.get_bookmark(
+            Context.state, self.parent_stream.name, self.parent_stream.replication_key)
+        self.update_bookmark(max_bookmark)
 
 Context.stream_objects['transactions'] = Transactions

--- a/tests/test_bookmarks_updated.py
+++ b/tests/test_bookmarks_updated.py
@@ -77,7 +77,7 @@ class BookmarkTest(BaseTapTest):
        #simulated_states = self.calculated_states_by_stream(first_sync_bookmark)
 
         # We are hardcoding the updated state to ensure that we get atleast 1 record in second sync. These values have been provided after reviewing the max bookmark value for each of the streams
-        simulated_states = {'products': {'updated_at': '2021-12-20T05:10:05.000000Z'}, 'collects': {'updated_at': '2021-09-01T09:08:28.000000Z'}, 'abandoned_checkouts': {'updated_at': '2022-02-02T16:00:00.000000Z'}, 'inventory_levels': {'updated_at': '2021-12-20T05:09:34.000000Z'}, 'locations': {'updated_at': '2021-07-20T09:00:22.000000Z'}, 'events': {'created_at': '2021-12-20T05:09:01.000000Z'}, 'inventory_items': {'updated_at': '2021-09-15T19:44:11.000000Z'}, 'transactions': {'created_at': '2021-12-20T00:08:52-05:00'}, 'metafields': {'updated_at': '2021-09-07T21:18:05.000000Z'}, 'order_refunds': {'created_at': '2021-05-01T17:41:18.000000Z'}, 'customers': {'updated_at': '2021-12-20T05:08:17.000000Z'}, 'orders': {'updated_at': '2021-12-20T05:09:01.000000Z'}, 'custom_collections': {'updated_at': '2021-12-20T17:41:18.000000Z'}}
+        simulated_states = {'products': {'updated_at': '2024-09-14T03:01:11.000000Z'}, 'collects': {'updated_at': '2021-09-01T09:08:28.000000Z'}, 'abandoned_checkouts': {'updated_at': '2022-02-02T16:00:00.000000Z'}, 'inventory_levels': {'updated_at': '2021-12-20T05:09:34.000000Z'}, 'locations': {'updated_at': '2021-07-20T09:00:22.000000Z'}, 'events': {'created_at': '2021-12-20T05:09:01.000000Z'}, 'inventory_items': {'updated_at': '2021-09-15T19:44:11.000000Z'}, 'transactions': {'created_at': '2021-12-20T00:08:52-05:00'}, 'metafields': {'updated_at': '2025-01-21T13:28:24.000000Z'}, 'order_refunds': {'created_at': '2021-05-01T17:41:18.000000Z'}, 'customers': {'updated_at': '2021-12-20T05:08:17.000000Z'}, 'orders': {'updated_at': '2021-12-20T05:09:01.000000Z'}, 'custom_collections': {'updated_at': '2024-12-13T08:42:56.000000Z'}}
 
         for stream, updated_state in simulated_states.items():
             new_state['bookmarks'][stream] = updated_state
@@ -148,7 +148,7 @@ class BookmarkTest(BaseTapTest):
                 for record in second_sync_messages:
                     replication_key_value = record.get(replication_key)
                     # verify the 2nd sync replication key value is greater or equal to the 1st sync bookmarks
-                    self.assertGreaterEqual(replication_key_value, simulated_bookmark_value, msg="Second sync records do not respect the previous                                                  bookmark")
+                    self.assertGreaterEqual(self.convert_state_to_utc(replication_key_value), simulated_bookmark_value, msg="Second sync records do not respect the previous                                                  bookmark")
                     # verify the 2nd sync bookmark value is the max replication key value for a given stream
                     self.assertLessEqual(replication_key_value, second_bookmark_value_utc, msg="Second sync bookmark was set incorrectly, a record with a greater replication key value was synced")
 

--- a/tests/test_interrupted_sync.py
+++ b/tests/test_interrupted_sync.py
@@ -89,12 +89,12 @@ class InterruptedSyncTest(BaseTapTest):
 
         base_state = {'bookmarks':
                      {'currently_sync_stream': currently_syncing_stream,
-                      'customers': {'updated_at': '2023-03-28T18:53:28.000000Z'},
-                      'events': {'created_at': '2023-01-22T05:05:53.000000Z'},
-                      'metafields': {'updated_at': '2023-01-07T21:18:05.000000Z'},
-                      'orders': {'updated_at': '2023-01-22T05:07:44.000000Z'},
-                      'products': {'updated_at': '2023-01-22T05:05:56.000000Z'},
-                      'transactions': {'created_at': '2022-06-26T00:06:38-04:00'}
+                      'customers': first_sync_state.get('bookmarks').get('customers'),
+                      'events': first_sync_state.get('bookmarks').get('events'),
+                      'metafields': first_sync_state.get('bookmarks').get('metafields'),
+                      'orders': first_sync_state.get('bookmarks').get('orders'),
+                      'products': first_sync_state.get('bookmarks').get('products'),
+                      'transactions': first_sync_state.get('bookmarks').get('transactions')
                       }}
 
         # remove yet to be synced streams from base state and then set new state

--- a/tests/test_interrupted_sync.py
+++ b/tests/test_interrupted_sync.py
@@ -87,17 +87,13 @@ class InterruptedSyncTest(BaseTapTest):
         completed_streams = stream_groups.get('completed')
         yet_to_be_synced_streams = stream_groups.get('yet_to_be_synced')
 
-        base_state = {
-            "bookmarks": {
-                "currently_sync_stream": currently_syncing_stream,
-                "customers": first_sync_state.get("bookmarks").get("customers"),
-                "events": first_sync_state.get("bookmarks").get("events"),
-                "metafields": first_sync_state.get("bookmarks").get("metafields"),
-                "orders": first_sync_state.get("bookmarks").get("orders"),
-                "products": first_sync_state.get("bookmarks").get("products"),
-                "transactions": first_sync_state.get("bookmarks").get("transactions"),
-            }
-        }
+        base_state = {"bookmarks": {"currently_sync_stream": currently_syncing_stream,
+                                    "customers": first_sync_state.get("bookmarks").get("customers"),
+                                    "events": first_sync_state.get("bookmarks").get("events"),
+                                    "metafields": first_sync_state.get("bookmarks").get("metafields"),
+                                    "orders": first_sync_state.get("bookmarks").get("orders"),
+                                    "products": first_sync_state.get("bookmarks").get("products"),
+                                    "transactions": first_sync_state.get("bookmarks").get("transactions"),}}
 
         # remove yet to be synced streams from base state and then set new state
         new_state = {

--- a/tests/test_interrupted_sync.py
+++ b/tests/test_interrupted_sync.py
@@ -87,15 +87,17 @@ class InterruptedSyncTest(BaseTapTest):
         completed_streams = stream_groups.get('completed')
         yet_to_be_synced_streams = stream_groups.get('yet_to_be_synced')
 
-        base_state = {'bookmarks':
-                     {'currently_sync_stream': currently_syncing_stream,
-                      'customers': first_sync_state.get('bookmarks').get('customers'),
-                      'events': first_sync_state.get('bookmarks').get('events'),
-                      'metafields': first_sync_state.get('bookmarks').get('metafields'),
-                      'orders': first_sync_state.get('bookmarks').get('orders'),
-                      'products': first_sync_state.get('bookmarks').get('products'),
-                      'transactions': first_sync_state.get('bookmarks').get('transactions')
-                      }}
+        base_state = {
+            "bookmarks": {
+                "currently_sync_stream": currently_syncing_stream,
+                "customers": first_sync_state.get("bookmarks").get("customers"),
+                "events": first_sync_state.get("bookmarks").get("events"),
+                "metafields": first_sync_state.get("bookmarks").get("metafields"),
+                "orders": first_sync_state.get("bookmarks").get("orders"),
+                "products": first_sync_state.get("bookmarks").get("products"),
+                "transactions": first_sync_state.get("bookmarks").get("transactions"),
+            }
+        }
 
         # remove yet to be synced streams from base state and then set new state
         new_state = {

--- a/tests/test_interrupted_sync.py
+++ b/tests/test_interrupted_sync.py
@@ -196,18 +196,8 @@ class InterruptedSyncTest(BaseTapTest):
                 self.assertIsNotNone(resuming_bookmark_value)
                 self.assertTrue(self.is_expected_date_format(resuming_bookmark_value))
 
-                # verify the resuming bookmark is greater than 1st sync bookmark
-                # This is the expected behaviour for shopify as they are using date windowing
-                # TDL-17096 : Resuming bookmark value is getting assigned from execution time
-                # rather than the actual bookmark time for some streams.
-                # TODO transactions stream has equal bookmarks, orders stream has shown both equal
-                #   and greater than bookmark behavior, confirm if this is correct
-                if stream == 'transactions':
-                    self.assertEqual(resuming_bookmark_value, first_bookmark_value)
-                elif stream == 'orders':
-                    self.assertGreaterEqual(resuming_bookmark_value, first_bookmark_value)
-                else:
-                    self.assertGreater(resuming_bookmark_value, first_bookmark_value)
+                # verify the resuming bookmark is greater or equal than 1st sync bookmark
+                self.assertGreaterEqual(resuming_bookmark_value, first_bookmark_value)
 
                 # verify oldest record from resuming sync respects bookmark from previous sync
                 if stream in new_state['bookmarks'].keys() and resuming_sync_messages:


### PR DESCRIPTION
# Description of change
- Same fix #197 for older version of tap.
- Update bookmark logic for transactions and order_refunds. More details can be found [here](https://qlik-dev.atlassian.net/browse/TDL-26766).

To synchronize transactions, we first fetch recent order records based on the transaction_orders bookmark. We then make API calls for each fetched order ID to retrieve the associated transaction records. The transaction_orders bookmark is based on the updated_at value of the order records, while the transactions bookmark uses the created_at value from the transaction records as the replication key. At the end of extraction, we update the bookmarks with the maximum replication key values encountered.

The extraction began on 2024-11-29T11:02, using the following state:

```
{
    "bookmarks": {
        "transactions": {
            "created_at": "2024-11-29T10:33:55.000000Z",
            "transaction_orders": {
                "updated_at": "2024-11-29T10:33:36.000000Z"
            }
        }
    }
}
```
The API call was made to fetch orders within the date range 2024-11-29T10:33:36+00:00 to 2024-11-29T11:05:24+00:00. However, the customer's updated record had a updated_at value of 2024-11-29T11:06:49, which fell outside the current extraction window and was therefore missed.

At 11:05:27, all eligible orders were fetched, and API calls began to retrieve transactions for each order. At 11:07:30, an API call was made for order X, where a new transaction was created at 2024-11-29T11:06:52. This transaction record was fetched successfully, and since its created_at value was the maximum seen so far, the transactions bookmark was updated accordingly. The resulting bookmarks were:



```
{
    "bookmarks": {
        "transactions": {
            "created_at": "2024-11-29T11:06:52.000000Z",
            "transaction_orders": {
                "updated_at": "2024-11-29T11:05:15.000000Z"
            }
        }
    }
}
```

In the next extraction window, orders were fetched within the range 2024-11-29T11:05:15*to {}2024-11-29T11:35:36{*}. This included the expected order ID 5677413597302 and its transactions. However, one transaction from this order had a created_at value of 2024-11-29T11:06:49, which was less than the transactions bookmark of 2024-11-29T11:06:52. As a result, this transaction was ignored and not written to the output, even though it was fetched from the API.

**To resolve this issue, we use the transaction_orders bookmark (parent) as the bookmark for the transactions stream (child). This approach ensures consistency between the parent and child extraction windows and prevents valid transactions from being skipped.**

# QA steps
 - Resync the transactions and refunds_order stream and verify that no more records are missing.
 - Sync the tap with all streams and found that there is no change in bookmark of rest of the streams.
 
# Risks

# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
