### PR TITLE
added lost datapoints from graphql migration

### DIFF
--- a/tap_shopify/schemas/product_variants.json
+++ b/tap_shopify/schemas/product_variants.json
@@ -159,6 +159,79 @@
                     ]
                 }
             }
+        },
+        "inventoryItem": {
+            "type": [
+                "null",
+                "object"
+            ],
+            "properties": {
+                "id": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "inventoryLevel": {
+                    "type": [
+                        "null",
+                        "object"
+                    ],
+                    "properties": {
+                        "location": {
+                            "type": [
+                                "null",
+                                "object"
+                            ],
+                            "properties": {
+                                "fulfillmentService": {
+                                    "type": [
+                                        "null",
+                                        "object"
+                                    ],
+                                    "properties": {
+                                        "handle": {
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "measurement": {
+                    "type": [
+                        "null",
+                        "object"
+                    ],
+                    "properties": {
+                        "weight": {
+                            "type": [
+                                "null",
+                                "object"
+                            ],
+                            "properties": {
+                                "unit": {
+                                    "type": [
+                                        "null",
+                                        "string"
+                                    ]
+                                },
+                                "value": {
+                                    "type": [
+                                        "null",
+                                        "string"
+                                    ],
+                                    "format": "singer.decimal"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/tap_shopify/schemas/product_variants.json
+++ b/tap_shopify/schemas/product_variants.json
@@ -173,60 +173,42 @@
                     ]
                 },
                 "inventoryLevel": {
-                    "type": [
-                        "null",
-                        "object"
-                    ],
-                    "properties": {
-                        "location": {
+                    "location": {
+                        "fulfillmentService": {
                             "type": [
                                 "null",
                                 "object"
                             ],
                             "properties": {
-                                "fulfillmentService": {
+                                "handle": {
                                     "type": [
                                         "null",
-                                        "object"
-                                    ],
-                                    "properties": {
-                                        "handle": {
-                                            "type": [
-                                                "null",
-                                                "string"
-                                            ]
-                                        }
-                                    }
+                                        "string"
+                                    ]
                                 }
                             }
                         }
                     }
                 },
                 "measurement": {
-                    "type": [
-                        "null",
-                        "object"
-                    ],
-                    "properties": {
-                        "weight": {
-                            "type": [
-                                "null",
-                                "object"
-                            ],
-                            "properties": {
-                                "unit": {
-                                    "type": [
-                                        "null",
-                                        "string"
-                                    ]
-                                },
-                                "value": {
-                                    "type": [
-                                        "null",
-                                        "string"
-                                    ],
-                                    "format": "singer.decimal"
-                                }
+                    "weight": {
+                        "type": [
+                            "null",
+                            "object"
+                        ],
+                        "properties": {
+                            "unit": {
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "value": {
+                                "type": [
+                                    "null",
+                                    "string"
+                                ],
+                                "format": "singer.decimal"
                             }
                         }
                     }


### PR DESCRIPTION
# Description of change
During the migration of the deprecated rest API for the product and inventory items streams, the initial schemas for the graphql streams had omitted some fields. This PR will add in the omitted fields back using their updated aliases in the shopify `product_variant` graphql [endpoint](https://shopify.dev/docs/api/admin-graphql/2024-07/queries/productVariants):
  - weight -> `inventoryItem.measurement.weight.(unit|value)`
  - fulfillment_service -> `inventoryItem.inventoryLevel.location.fulfillmentService.handle`

# QA steps
 - [ x] manual qa steps passing (list below)
    - discovery and sync successful with new fields marked as available
 
# Risks
graphql mapping names not properly spelled, thus returning null values or errors based on field name.

# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
