### PR TITLE
Add weight unit + value to productVariant query

### DIFF
--- a/tap_shopify/schemas/product_variants.json
+++ b/tap_shopify/schemas/product_variants.json
@@ -171,6 +171,35 @@
                         "null",
                         "string"
                     ]
+                },
+                "measurement": {
+                    "type": [
+                        "null",
+                        "object"
+                    ],
+                    "properties": {
+                        "weight": {
+                            "type": [
+                                "null",
+                                "object"
+                            ],
+                            "properties": {
+                                "unit": {
+                                    "type": [
+                                        "null",
+                                        "string"
+                                    ]
+                                },
+                                "value": {
+                                    "type": [
+                                        "null",
+                                        "string"
+                                    ],
+                                    "format": "singer.decimal"
+                                }
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/tap_shopify/streams/graphql/gql_queries.py
+++ b/tap_shopify/streams/graphql/gql_queries.py
@@ -158,13 +158,21 @@ def get_product_variant_query():
                         title
                         updatedAt
                         product { id }
-                        inventoryItem { id }
+                        inventoryItem { 
+                            id 
+                            measurement {
+                                weight {
+                                    unit
+                                    value
+                                }
+                            }
+                        }
                     }
-                    }
-                    pageInfo {
-                        hasNextPage
-                        endCursor
-                    }
+                }
+                pageInfo {
+                    hasNextPage
+                    endCursor
+                }
             }
         }
         """


### PR DESCRIPTION
# Description of change
In the prior version of the `products` schema, product variants included `weight` (FLOAT) and `weight_unit` (STRING) properties. To achieve parity with the prior version this change adds the weight unit and value from the inventoryItem associated with a product variant to its query + schema

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
