### PR TITLE
Improve metafields query performance

### DIFF
--- a/tap_shopify/streams/graphql/gql_queries.py
+++ b/tap_shopify/streams/graphql/gql_queries.py
@@ -238,8 +238,8 @@ def get_metafields_query(resource):
         return get_metafield_query_shop()
 
     qry = """
-        query getMetafields( $first: Int!, $after: String $query: String) {
-        RESOURCE(first: $first after: $after query: $query) {
+        query getMetafields( $first: Int!, $after: String, $query: String ) {
+        RESOURCE(first: $first, after: $after, query: $query, sortKey: UPDATED_AT) {
             edges {
             node {
                 metafields(first: $first) {


### PR DESCRIPTION
# Description of change

Our shopify integration in Stitch has recently been experiencing unexpected internal server errors when querying for various resources' metafields. For example,

```
2025-03-20 19:29:03,358Z    tap - CRITICAL ShopifyAPIError
2025-03-20 19:29:03,358Z    tap - Traceback (most recent call last):
2025-03-20 19:29:03,358Z    tap -   File "/code/orchestrator/tap-env/lib/python3.11/site-packages/tap_shopify/streams/metafields.py", line 75, in call_api
2025-03-20 19:29:03,358Z    tap -     raise ShopifyAPIError(response['errors'])
2025-03-20 19:29:03,358Z    tap - tap_shopify.streams.base.ShopifyAPIError: [{'message': 'Internal error. Looks like something went wrong on our end.\nRequest ID: [REDACTED] (include this in support requests).', 'extensions': {'code': 'INTERNAL_SERVER_ERROR', 'requestId': '[REDACTED]'}}]
```

According to Shopify support, we can improve query performance and mitigate errors like this by adding a sort key to our graphql queries. See docs: https://shopify.dev/docs/api/usage/search-syntax#using-created_at-in-a-range-query

cc @sgandhi1311 

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
