### PR TITLE
Skip the author field on missing `read_users` scope

### DIFF
--- a/tap_shopify/__init__.py
+++ b/tap_shopify/__init__.py
@@ -54,7 +54,10 @@ def has_read_users_access():
     scopes = fetch_app_scopes()
     # If the app does not have the 'read_users' scope, return False
     if 'read_users' not in scopes:
-        LOGGER.warning("Skipping '%s' field: 'read_users' scope is not granted for public apps.", ", ".join(UNSUPPORTED_FIELDS))
+        LOGGER.warning(
+            "Skipping '%s' field: 'read_users' scope is not granted for public apps.",
+            ", ".join(UNSUPPORTED_FIELDS)
+        )
         return False
     return True
 

--- a/tap_shopify/__init__.py
+++ b/tap_shopify/__init__.py
@@ -46,14 +46,12 @@ def fetch_app_scopes():
       }
     }
     """
-    resp = shopify.GraphQL().execute(query)
-    data = json.loads(resp)
+    data = json.loads(shopify.GraphQL().execute(query))
     return {s["handle"] for s in data["data"]["currentAppInstallation"]["accessScopes"]}
 
 def has_read_users_access():
-    scopes = fetch_app_scopes()
     # If the app does not have the 'read_users' scope, return False
-    if 'read_users' not in scopes:
+    if 'read_users' not in fetch_app_scopes():
         LOGGER.warning(
             "Skipping '%s' field: 'read_users' scope is not granted for public apps.",
             ", ".join(UNSUPPORTED_FIELDS)

--- a/tap_shopify/context.py
+++ b/tap_shopify/context.py
@@ -34,6 +34,8 @@ class Context():
         selected_fields = set()
         for breadcrumb, data in stream_metadata.items():
             if len(breadcrumb) == 2:
+                if data.get('inclusion') == 'unsupported':
+                    continue
                 if data.get('selected') or data.get('inclusion') == 'automatic':
                     selected_fields.add(breadcrumb[1])
 

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -165,10 +165,9 @@ class DiscoveryTest(BaseTapTest):
                                      expected_automatic_fields,
                                      actual_automatic_fields))
 
-                # verify that all other fields have inclusion of available
-                # This assumes there are no unsupported fields for SaaS sources
+                # verify that all other fields have inclusion of available or unsupported
                 self.assertTrue(
-                    all({item.get("metadata").get("inclusion") == "available"
+                    all({(item.get("metadata").get("inclusion") == "available" or item.get("metadata").get("inclusion") == "unsupported")
                          for item in metadata
                          if item.get("breadcrumb", []) != []
                          and item.get("breadcrumb", ["properties", None])[1]

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -140,13 +140,18 @@ class DiscoveryTest(BaseTapTest):
                                      expected_automatic_fields,
                                      actual_automatic_fields))
 
-                # verify that all other fields have inclusion of available
-                # This assumes there are no unsupported fields for SaaS sources
+                # verify that all other fields have inclusion of available or unsupported
                 self.assertTrue(
-                    all({value.get("inclusion") == "available" for key, value
-                         in schema["properties"].items()
-                         if key not in actual_automatic_fields}),
-                    msg="Not all non key properties are set to available in annotated schema")
+                    all(
+                        (
+                            value.get("inclusion") == "available"
+                            or value.get("inclusion") == "unsupported"
+                        )
+                        for key, value in schema["properties"].items()
+                        if key not in actual_automatic_fields
+                    ),
+                    msg="Not all non key properties are set to available in annotated schema"
+                )
 
                 # verify that primary, replication and foreign keys
                 # are given the inclusion of automatic in metadata.

--- a/tests/unittests/test_token_check_in_discover.py
+++ b/tests/unittests/test_token_check_in_discover.py
@@ -24,14 +24,16 @@ def connection_error_raiser():
 @mock.patch('tap_shopify.utils.parse_args')
 @mock.patch('tap_shopify.discover', side_effect=tap_shopify.discover)
 @mock.patch("builtins.print")
+@mock.patch("tap_shopify.has_read_users_access")
 class TestTokenInDiscoverMode(unittest.TestCase):
 
     @mock.patch('tap_shopify.initialize_shopify_client', side_effect=resource_not_found_raiser)
-    def test_resource_not_found(self, mocked_client, mocked_print, mocked_discover, mocked_args):
+    def test_resource_not_found(self, mocked_client, mocked_access, mocked_print, mocked_discover, mocked_args):
         '''
             Verify exception is raised for ResourceNotFound with proper error message and
             test that discover mode is called 
         '''
+        mocked_access.return_value = True
         mocked_args.return_value = Args()
         try:
             tap_shopify.main()
@@ -42,11 +44,12 @@ class TestTokenInDiscoverMode(unittest.TestCase):
             self.assertEqual(mocked_print.call_count, 0)
 
     @mock.patch('tap_shopify.initialize_shopify_client', side_effect=unauthorized_access_raiser)
-    def test_unauthorized_access(self, mocked_client, mocked_print, mocked_discover, mocked_args):
+    def test_unauthorized_access(self, mocked_client, mocked_access, mocked_print, mocked_discover, mocked_args):
         '''
             Verify exception is raised for UnauthorizedAccess with proper error message and
             test that discover mode is called 
         '''
+        mocked_access.return_value = True
         mocked_args.return_value = Args()
         try:
             tap_shopify.main()
@@ -57,11 +60,12 @@ class TestTokenInDiscoverMode(unittest.TestCase):
             self.assertEqual(mocked_print.call_count, 0)
 
     @mock.patch('tap_shopify.initialize_shopify_client', side_effect=connection_error_raiser)
-    def test_connection_error(self, mocked_client, mocked_print, mocked_discover, mocked_args):
+    def test_connection_error(self, mocked_client, mocked_access, mocked_print, mocked_discover, mocked_args):
         '''
             Verify exception is raised for ConnectionError with proper error message and
             test that discover mode is called 
         '''
+        mocked_access.return_value = True
         mocked_args.return_value = Args()
         try:
             tap_shopify.main()
@@ -72,11 +76,12 @@ class TestTokenInDiscoverMode(unittest.TestCase):
             self.assertEqual(mocked_print.call_count, 0)
 
     @mock.patch('tap_shopify.initialize_shopify_client')
-    def test_no_error(self, mocked_client, mocked_print, mocked_discover, mocked_args):
+    def test_no_error(self, mocked_client, mocked_access, mocked_print, mocked_discover, mocked_args):
         '''
             Verify that if no error during discover then print should be called once for
             writing catalog
         '''
+        mocked_access.return_value = True
         mocked_args.return_value = Args()
         tap_shopify.main()
         self.assertEqual(mocked_discover.call_count, 1)


### PR DESCRIPTION
# Description of change

This PR tap to skip the author field in the stream and mark it as unsupported, due to Shopify access restrictions on public apps.

The author field in the streams requires the read_users access scope, which is not permitted for public apps. Attempting to extract this field resulted in the following error:

`Access denied for author field. Required access: read_users access scope. Also: The app must be a finance embedded app or installed on a Shopify Plus or Advanced store. Contact Shopify Support to enable this scope for your app.`

**Shopify has since confirmed that:**

read_users cannot be added to public apps, making the author field permanently inaccessible in such contexts.

# Changes

- The author field is now skipped during extraction.
- The field is explicitly marked as unsupported in the schema.

# QA steps
 - [x] automated tests passing
 - [x] manual qa steps passing (list below)
 -- Checked the extraction by skipping the author field.
 -- Performed PR-alpha on the connection
 
# Risks

# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [x] this PR has been written with the help of GitHub Copilot or another generative AI tool
