### PR TITLE
Add `Order.customAttributes` and `Order.number`

### DIFF
--- a/tap_shopify/schemas/orders.json
+++ b/tap_shopify/schemas/orders.json
@@ -299,6 +299,32 @@
       }
     },
     "currentTotalWeight": { "type": ["null", "number"] },
+    "customAttributes": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "object"
+        ],
+        "properties": {
+          "key": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "value": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      }
+    },
     "customer": {
       "type": [
         "null",
@@ -683,6 +709,7 @@
     },
     "name": { "type": ["null", "string"] },
     "note": { "type": ["null", "string"] },
+    "number": { "type": ["null", "number"] },
     "netPaymentSet": {
       "type": ["null", "object"],
       "properties": {

--- a/tap_shopify/streams/orders.py
+++ b/tap_shopify/streams/orders.py
@@ -273,6 +273,10 @@ class Orders(Stream):
                                 }
                             }
                             currentTotalWeight
+                            customAttributes {
+                                key
+                                value
+                            }
                             customer {
                                 id
                                 email
@@ -369,6 +373,7 @@ class Orders(Stream):
                             }
                             name
                             note
+                            number
                             netPaymentSet {
                                 presentmentMoney {
                                     amount


### PR DESCRIPTION
# Description of change
The following fields were missed on the order stream when migrating from REST to GraphQL so adding them back:
- `customAttributes` (formerly `note_attributes` on the REST order resource)
- `number` (formerly `order_number` on the REST order resource)

cc @sgandhi1311 @vishalp-dev @RushiT0122

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
