### PR TITLE
Raise the error to trigger mail to customers for the new connections from v2 to v3

### DIFF
--- a/tap_shopify/__init__.py
+++ b/tap_shopify/__init__.py
@@ -228,8 +228,8 @@ def main():
 
                 # Raise exception to trigger Stitch notification
                 raise Exception(
-                    "IMPORTANT: Version 3 of this tap has been in production for over 3 months. "
-                    "Stitch will no longer guarantee support for version 2. "
+                    "Version 3 of this integration has been available as of 2025-03-29. "
+                    "Stitch does not guarantee support for deprecated integrations. "
                     "Please upgrade to version 3 to ensure continued support."
                 )
     except pyactiveresource.connection.ResourceNotFound as exc:


### PR DESCRIPTION
# Description of change
This PR introduces a mechanism to notify customers still using tap version 2 to upgrade to version 3, which has been in production for over 3 months.
The warning is raised by checking - At least 7 days have passed since the last notification
The last_exception_triggered timestamp is stored in the tap’s Singer state using singer.write_bookmark().


# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
