### PR TITLE
Set max size of pagination to 30 for fullfilment_orders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 3.6.2
+  * Set max_size of pagination to 30 for fullfilment_orders [#230](https://github.com/singer-io/tap-shopify/pull/230)
+
 ## 3.6.1
   * Dependency upgrades [#228](https://github.com/singer-io/tap-shopify/pull/228)
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages
 
 setup(
     name="tap-shopify",
-    version="3.6.1",
+    version="3.6.2",
     description="Singer.io tap for extracting Shopify data",
     author="Stitch",
     url="http://github.com/singer-io/tap-shopify",

--- a/tap_shopify/streams/fulfillment_orders.py
+++ b/tap_shopify/streams/fulfillment_orders.py
@@ -12,6 +12,30 @@ class FulfillmentOrders(Stream):
     data_key = "fulfillmentOrders"
     replication_key = "updatedAt"
 
+    # pylint: disable=W0221,fixme
+    def get_query_params(self, updated_at_min, updated_at_max, cursor=None):
+        """
+        Construct query parameters for GraphQL requests.
+
+        Args:
+            updated_at_min (str): Minimum updated_at timestamp.
+            updated_at_max (str): Maximum updated_at timestamp.
+            cursor (str): Pagination cursor, if any.
+
+        Returns:
+            dict: Dictionary of query parameters.
+        """
+        rkey = self.camel_to_snake(self.replication_key)
+
+        params = {
+            "query": f"{rkey}:>='{updated_at_min}' AND {rkey}:<'{updated_at_max}'",
+            "first": self.results_per_page if self.results_per_page <= 30 else 30,
+        }
+
+        if cursor:
+            params["after"] = cursor
+        return params
+
     def transform_childitems(self, data, parent_id, key, next_page_key):
         """
         Paginate child items.


### PR DESCRIPTION
# Description of change
Set max size of pagination to 30 for fullfilment_orders

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
