### PR TITLE
Query and extract multiple pages of products for each collection

### DIFF
--- a/tap_shopify/streams/collections.py
+++ b/tap_shopify/streams/collections.py
@@ -37,7 +37,7 @@ class Collections(Stream):
 
             # Fetch the next page of data
             response = self.call_api(params, query=query)
-            products_data = response.get("node", {}).get("products", {})
+            products_data = response.get("edges", [{}])[0].get("node", {}).get("products", {})
             product_ids.extend(
                 node["id"]
                 for item in products_data.get("edges", [])


### PR DESCRIPTION
# Description of change
This is a one-liner that adjusts the `collections` stream to extract multiple pages of `products` sub-results. 

Prior to this PR, only the 1st page of `collections.products` is being extracted for each collection. This is documented in #224.

Specifically, this PR updates the handling in `Collections.transform_products` to match the shape of the GraphQL API response.

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
