### PR TITLE
New automatic_keys Support and Bulk State Persistence Logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 3.7.2
+  * New automatic_keys Support and Bulk State Persistence Logic [#237](https://github.com/singer-io/tap-shopify/pull/237)
+
 ### 3.7.1
   * Query and extract multiple pages of products for each collection [#227](https://github.com/singer-io/tap-shopify/pull/231)
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages
 
 setup(
     name="tap-shopify",
-    version="3.7.1",
+    version="3.7.2",
     description="Singer.io tap for extracting Shopify data",
     author="Stitch",
     url="http://github.com/singer-io/tap-shopify",

--- a/tap_shopify/__init__.py
+++ b/tap_shopify/__init__.py
@@ -86,7 +86,8 @@ def get_discovery_metadata(stream, schema):
         mdata = metadata.write(mdata, (), 'valid-replication-keys', [stream.replication_key])
 
     for field_name in schema['properties'].keys():
-        if field_name in stream.key_properties or field_name == stream.replication_key or field_name in stream.automatic_keys:
+        if field_name in stream.key_properties or field_name == stream.replication_key \
+            or field_name in stream.automatic_keys:
             mdata = metadata.write(mdata, ('properties', field_name), 'inclusion', 'automatic')
         elif field_name in UNSUPPORTED_FIELDS and not has_read_users_access():
             mdata = metadata.write(mdata, ('properties', field_name), 'inclusion', 'unsupported')

--- a/tap_shopify/__init__.py
+++ b/tap_shopify/__init__.py
@@ -86,7 +86,7 @@ def get_discovery_metadata(stream, schema):
         mdata = metadata.write(mdata, (), 'valid-replication-keys', [stream.replication_key])
 
     for field_name in schema['properties'].keys():
-        if field_name in stream.key_properties or field_name == stream.replication_key:
+        if field_name in stream.key_properties or field_name == stream.replication_key or field_name in stream.automatic_keys:
             mdata = metadata.write(mdata, ('properties', field_name), 'inclusion', 'automatic')
         elif field_name in UNSUPPORTED_FIELDS and not has_read_users_access():
             mdata = metadata.write(mdata, ('properties', field_name), 'inclusion', 'unsupported')

--- a/tap_shopify/streams/base.py
+++ b/tap_shopify/streams/base.py
@@ -132,6 +132,7 @@ class Stream():
     name = None
     replication_method = 'INCREMENTAL'
     replication_key = 'updatedAt'
+    automatic_keys = []
     key_properties = ['id']
     date_window_size = None
     data_key = None

--- a/tap_shopify/streams/order_refunds.py
+++ b/tap_shopify/streams/order_refunds.py
@@ -11,7 +11,7 @@ class OrderRefunds(Stream):
     data_key = "orders"
     child_data_key = "refunds"
     replication_key = "updatedAt"
-    automatic_keys = ["orders"]
+    automatic_keys = ["order"]
 
     # pylint: disable=too-many-locals
     def get_objects(self):

--- a/tap_shopify/streams/order_refunds.py
+++ b/tap_shopify/streams/order_refunds.py
@@ -11,6 +11,7 @@ class OrderRefunds(Stream):
     data_key = "orders"
     child_data_key = "refunds"
     replication_key = "updatedAt"
+    automatic_keys = ["orders"]
 
     # pylint: disable=too-many-locals
     def get_objects(self):

--- a/tap_shopify/streams/orders.py
+++ b/tap_shopify/streams/orders.py
@@ -1162,7 +1162,7 @@ class Orders(Stream):
         current_order = None
         current_line_items = []
 
-        for line in resp.iter_lines():
+        for line in resp.iter_lines(chunk_size=1024*1024):
             if not line:
                 continue
             rec = json.loads(line)

--- a/tap_shopify/streams/orders.py
+++ b/tap_shopify/streams/orders.py
@@ -1162,7 +1162,7 @@ class Orders(Stream):
         current_order = None
         current_line_items = []
 
-        for line in resp.iter_lines(chunk_size=1024*1024):
+        for line in resp.iter_lines():
             if not line:
                 continue
             rec = json.loads(line)

--- a/tests/test_automatic_fields.py
+++ b/tests/test_automatic_fields.py
@@ -64,6 +64,9 @@ class MinimumSelectionTest(BaseTapTest):
                 stream_metadata = self.expected_metadata().get(stream, {})
                 expected_primary_keys = self.expected_primary_keys().get(stream, set())
 
+                if stream == "order_refunds":
+                    expected_primary_keys = expected_primary_keys | {"order"}
+
                 # collect records
                 messages = synced_records.get(stream)
 

--- a/tests/test_automatic_fields.py
+++ b/tests/test_automatic_fields.py
@@ -64,8 +64,7 @@ class MinimumSelectionTest(BaseTapTest):
                 stream_metadata = self.expected_metadata().get(stream, {})
                 expected_primary_keys = self.expected_primary_keys().get(stream, set())
 
-                if stream == "order_refunds":
-                    expected_primary_keys = expected_primary_keys | {"order"}
+                extra_automatic_keys = {"order"} if stream == "order_refunds" else set()
 
                 # collect records
                 messages = synced_records.get(stream)
@@ -82,7 +81,7 @@ class MinimumSelectionTest(BaseTapTest):
                 # verify that only the automatic fields are sent to the target
                 self.assertEqual(
                     actual_fields_by_stream.get(stream, set()),
-                    expected_primary_keys |
+                    expected_primary_keys | extra_automatic_keys |
                     self.expected_replication_keys().get(stream, set()),
                     msg="The fields sent to the target are not the automatic fields"
                 )

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -129,6 +129,10 @@ class DiscoveryTest(BaseTapTest):
                 expected_primary_keys = self.expected_primary_keys()[stream]
                 expected_replication_keys = self.expected_replication_keys()[stream]
                 expected_automatic_fields = expected_primary_keys | expected_replication_keys
+                
+                # In the order_refunds stream, order field is explicitly marked as automatic
+                if stream == "order_refunds":
+                    expected_automatic_fields = expected_automatic_fields | {"order"}
 
                 # verify that primary, replication and foreign keys
                 # are given the inclusion of automatic in annotated schema.


### PR DESCRIPTION
# Description of change

### order_refunds stream:

- The order field is now included in the automatic_keys list (automatic_keys = ["order"] in order_refunds.py).
- In __init__.py, this means the order field will be marked with "inclusion": "automatic" in discovery metadata, as it's required for refunds pagination.

### orders stream:

- When a previous BULK operation is completed but not fully processed, the extraction for that bulk operation is performed in the current execution.
- Metadata for the bulk operation (such as bulk op id, status, created_at, last_date_window) is now saved to the state file during processing (see self.update_bookmark(..., bulk_op_metadata={...})).
- After processing, the bulk operation state is cleared to remove this metadata from the state file (self.clear_bulk_operation_state() is now called after extraction, not inside the loop).

### Core logic changes:

- The Stream base class now has an automatic_keys attribute, allowing streams to specify fields that should always be marked as "automatic" in metadata.
- The metadata discovery function now marks any field in automatic_keys as "automatic".

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
