### PR TITLE
update the bookmark value even if the record is not retrieved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 3.8.1
+  * Update the bookmark value even if the record is not retrieved [#247](https://github.com/singer-io/tap-shopify/pull/247)
+
 ### 3.8.0
   * Exponential backoff for Shopify bulk operations in progress [#246](https://github.com/singer-io/tap-shopify/pull/246)
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages
 
 setup(
     name="tap-shopify",
-    version="3.8.0",
+    version="3.8.1",
     description="Singer.io tap for extracting Shopify data",
     author="Stitch",
     url="http://github.com/singer-io/tap-shopify",

--- a/tap_shopify/streams/orders.py
+++ b/tap_shopify/streams/orders.py
@@ -1254,6 +1254,7 @@ class Orders(Stream):
             else:
                 LOGGER.info("No data returned for the date range: %s to %s",
                                last_updated_at, query_end)
+                current_bookmark = max(current_bookmark, query_end)
 
             self.clear_bulk_operation_state()
             last_updated_at = query_end

--- a/tap_shopify/streams/orders.py
+++ b/tap_shopify/streams/orders.py
@@ -1186,8 +1186,9 @@ class Orders(Stream):
                 if self.is_discount_application(rec):
                     # It's a discount application belonging to current_order
                     current_discount_applications.append(rec)
-                # It's a line item belonging to current_order
-                current_line_items.append(rec)
+                else:
+                    # It's a line item belonging to current_order
+                    current_line_items.append(rec)
             else:
                 if current_order:
                     current_order["lineItems"] = current_line_items
@@ -1200,6 +1201,7 @@ class Orders(Stream):
         # Yield the last parent group (if exists)
         if current_order:
             current_order["lineItems"] = current_line_items
+            current_order["discountApplications"] = current_discount_applications
             yield current_order
 
     def transform_object(self, obj):

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -12,8 +12,7 @@ KNOWN_MISSING_FIELDS = {
         'canDelete',
         'rawMessage',
         'canEdit',
-    },
-    'orders': {'discountApplications'}
+    }
 }
 
 class AllFieldsTest(BaseTapTest):


### PR DESCRIPTION
# Description of change
This PR ensures the bookmark value is updated even when no data is returned for a date range query, preventing potential data loss or unnecessary re-querying of empty time windows in the Shopify orders stream.

Key Changes:

- Updates the bookmark to the query end timestamp when no records are retrieved
- Increment version to 3.8.1
- Documents the change in the changelog

Additional:
- Update logic for the discountApplications field in the orders stream.

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
