### PR TITLE
Add pagination support for fulfillment line items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 3.9.0
+  * Add pagination support for fulfillment line items [#248](https://github.com/singer-io/tap-shopify/pull/248)
+
 ### 3.8.1
   * Update the bookmark value even if the record is not retrieved [#247](https://github.com/singer-io/tap-shopify/pull/247)
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages
 
 setup(
     name="tap-shopify",
-    version="3.8.1",
+    version="3.9.0",
     description="Singer.io tap for extracting Shopify data",
     author="Stitch",
     url="http://github.com/singer-io/tap-shopify",

--- a/tap_shopify/streams/fulfillment_orders.py
+++ b/tap_shopify/streams/fulfillment_orders.py
@@ -119,8 +119,7 @@ class FulfillmentOrders(Stream):
         while True:
             response = self.call_api(params, query=query, data_key="fulfillment")
             fulfillment_line_items.extend(
-                node for item in response.get("fulfillmentLineItems", {}).get("nodes", [])
-                if (node := item)
+                response.get("fulfillmentLineItems", {}).get("nodes", [])
             )
 
             page_info = response.get("fulfillmentLineItems", {}).get("pageInfo", {})
@@ -169,9 +168,9 @@ class FulfillmentOrders(Stream):
                 if item["fulfillmentLineItems"]["pageInfo"]["hasNextPage"]:
                     more_nodes = self.get_fulfillment_line_items(
                         fulfillment_id=item["id"],
-                        next_page = item["fulfillmentLineItems"]["pageInfo"]["endCursor"]
+                        next_page=item["fulfillmentLineItems"]["pageInfo"]["endCursor"]
                     )
-                    item["fulfillmentLineItems"] = more_nodes + initial_nodes
+                    item["fulfillmentLineItems"] = initial_nodes + more_nodes
                 else:
                     item["fulfillmentLineItems"] = initial_nodes
 

--- a/tap_shopify/streams/fulfillment_orders.py
+++ b/tap_shopify/streams/fulfillment_orders.py
@@ -73,7 +73,7 @@ class FulfillmentOrders(Stream):
         query = """
                 query FulfillmentLineItems($fulfillmentId: ID!, $next_page: String) {
                 fulfillment(id: $fulfillmentId) {
-                    fulfillmentLineItems(first: 1, after: $next_page) {
+                    fulfillmentLineItems(first: 100, after: $next_page) {
                     pageInfo {
                         hasNextPage
                         endCursor

--- a/tap_shopify/streams/fulfillment_orders.py
+++ b/tap_shopify/streams/fulfillment_orders.py
@@ -65,6 +65,72 @@ class FulfillmentOrders(Stream):
 
         return child_records
 
+    def get_fulfillment_line_items(self, fulfillment_id, next_page=None):
+        """
+        Fetch all fulfillment line items for a given fulfillment ID.
+        """
+        fulfillment_line_items = []
+        query = """
+                query FulfillmentLineItems($fulfillmentId: ID!, $next_page: String) {
+                fulfillment(id: $fulfillmentId) {
+                    fulfillmentLineItems(first: 1, after: $next_page) {
+                    pageInfo {
+                        hasNextPage
+                        endCursor
+                    }
+                    nodes {
+                        id
+                        quantity
+                        originalTotalSet {
+                        presentmentMoney {
+                            amount
+                            currencyCode
+                        }
+                        shopMoney {
+                            amount
+                            currencyCode
+                        }
+                        }
+                        discountedTotalSet {
+                        presentmentMoney {
+                            amount
+                            currencyCode
+                        }
+                        shopMoney {
+                            amount
+                            currencyCode
+                        }
+                        }
+                        lineItem {
+                        id
+                        }
+                    }
+                    }
+                }
+                }
+                """
+
+        params = {
+            "fulfillmentId": fulfillment_id,
+        }
+        if next_page:
+            params["next_page"] = next_page
+
+        while True:
+            response = self.call_api(params, query=query, data_key="fulfillment")
+            fulfillment_line_items.extend(
+                node for item in response.get("fulfillmentLineItems", {}).get("nodes", [])
+                if (node := item)
+            )
+
+            page_info = response.get("fulfillmentLineItems", {}).get("pageInfo", {})
+            if not page_info.get("hasNextPage"):
+                break
+
+            params["next_page"] = page_info.get("endCursor")
+
+        return fulfillment_line_items
+
     def transform_object(self, obj):
         """
         Transforms a collection object.
@@ -98,8 +164,16 @@ class FulfillmentOrders(Stream):
             )
             for item in obj["fulfillments"]:
                 item["fulfillmentOrders"] = item["fulfillmentOrders"]["nodes"]
-                item["fulfillmentLineItems"] = item["fulfillmentLineItems"]["nodes"]
                 item["events"] = item["events"]["nodes"]
+                initial_nodes = item["fulfillmentLineItems"]["nodes"]
+                if item["fulfillmentLineItems"]["pageInfo"]["hasNextPage"]:
+                    more_nodes = self.get_fulfillment_line_items(
+                        fulfillment_id=item["id"],
+                        next_page = item["fulfillmentLineItems"]["pageInfo"]["endCursor"]
+                    )
+                    item["fulfillmentLineItems"] = more_nodes + initial_nodes
+                else:
+                    item["fulfillmentLineItems"] = initial_nodes
 
         if obj.get("fulfillmentOrdersForMerge"):
             obj["fulfillmentOrdersForMerge"] = obj["fulfillmentOrdersForMerge"]["nodes"]
@@ -286,6 +360,10 @@ class FulfillmentOrders(Stream):
                                             }
                                         }
                                         fulfillmentLineItems(first: 3) {
+                                            pageInfo {
+                                                    hasNextPage
+                                                    endCursor
+                                                }
                                             nodes {
                                                 id
                                                 quantity
@@ -313,7 +391,6 @@ class FulfillmentOrders(Stream):
                                                     id
                                                 }
                                             }
-                                            
                                         }
                                         legacyResourceId
                                         order {


### PR DESCRIPTION
# Description of change
This PR adds pagination support for fulfillment line items in the fulfillment_orders stream. Previously, only the first 3 fulfillment line items were fetched; now the code handles paginated responses to retrieve all items when there are more than 3.

Changes:

Added a new method get_fulfillment_line_items to fetch paginated fulfillment line items
Updated transform_object to check for additional pages and fetch them if needed
Modified the GraphQL query to include pageInfo fields for pagination metadata

# QA steps
 - [x] automated tests passing
 - [x] manual qa steps passing (list below)
 - [x] Tested locally by manually modifying the page size
 - [X] Applied PR-alpha on the customer connection and verified it is working.
 
# Risks

# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
