### PR TITLE
Add support of client_cred grant type auth

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,6 +83,7 @@ jobs:
             source /usr/local/share/virtualenvs/tap-shopify/bin/activate
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
             source dev_env.sh
+            unset USE_STITCH_BACKEND
             mkdir /tmp/${CIRCLE_PROJECT_REPONAME}
             export STITCH_CONFIG_DIR=/tmp/${CIRCLE_PROJECT_REPONAME}
             source /usr/local/share/virtualenvs/tap-tester/bin/activate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 3.10.0
+  * Add support of client_cred grant type auth [#249](https://github.com/singer-io/tap-shopify/pull/249)
+  * Fix current bookmark value for no data time window [#251](https://github.com/singer-io/tap-shopify/pull/251)
+
 ### 3.9.0
   * Add pagination support for fulfillment line items [#248](https://github.com/singer-io/tap-shopify/pull/248)
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages
 
 setup(
     name="tap-shopify",
-    version="3.9.0",
+    version="3.10.0",
     description="Singer.io tap for extracting Shopify data",
     author="Stitch",
     url="http://github.com/singer-io/tap-shopify",

--- a/tap_shopify/__init__.py
+++ b/tap_shopify/__init__.py
@@ -224,7 +224,7 @@ def main():
         if dev_mode:
             LOGGER.warning("Executing Tap in Dev mode")
 
-        if 'access_token' in Context.config:
+        if 'api_key' not in Context.config:
             # Initialize the ShopifyClient for token management
             Context.client = ShopifyClient(
                 config_path=args.config_path,

--- a/tap_shopify/__init__.py
+++ b/tap_shopify/__init__.py
@@ -257,6 +257,8 @@ def main():
             msg = body.get('errors')
         finally:
             raise ShopifyError(exc, msg) from exc
+    except ShopifyUnauthorizedError as error:
+        raise error
     except ShopifyError as error:
         raise error
     except ShopifyAPIError as error:

--- a/tap_shopify/__init__.py
+++ b/tap_shopify/__init__.py
@@ -13,17 +13,18 @@ from singer import utils
 from singer import metadata
 from singer import Transformer
 from tap_shopify.context import Context
+from tap_shopify.client import ShopifyClient
 from tap_shopify.exceptions import ShopifyError, ShopifyAPIError
 from tap_shopify.streams.base import shopify_error_handling, get_request_timeout
 
-REQUIRED_CONFIG_KEYS = ["shop", "api_key"]
+REQUIRED_CONFIG_KEYS = ["shop"]
 LOGGER = singer.get_logger()
 SDC_KEYS = {'id': 'integer', 'name': 'string', 'myshopify_domain': 'string'}
 UNSUPPORTED_FIELDS = {"author"}
 
 @shopify_error_handling
 def initialize_shopify_client():
-    api_key = Context.config['api_key']
+    api_key = Context.config.get('access_token') or Context.config.get('api_key')
     shop = Context.config['shop']
     version = '2025-07'
     session = shopify.Session(shop, version, api_key)
@@ -218,6 +219,19 @@ def main():
 
         Context.config = args.config
         Context.state = args.state
+
+        dev_mode = args.dev
+        if dev_mode:
+            LOGGER.warning("Executing Tap in Dev mode")
+
+        if 'access_token' in Context.config:
+            # Initialize the ShopifyClient for token management
+            Context.client = ShopifyClient(
+                config_path=args.config_path,
+                config=Context.config,
+                dev_mode=dev_mode
+            )
+            Context.config['access_token'] = Context.client.access_token
 
         # If discover flag was passed, run discovery mode and dump output to stdout
         if args.discover:

--- a/tap_shopify/__init__.py
+++ b/tap_shopify/__init__.py
@@ -14,7 +14,7 @@ from singer import metadata
 from singer import Transformer
 from tap_shopify.context import Context
 from tap_shopify.client import ShopifyClient
-from tap_shopify.exceptions import ShopifyError, ShopifyAPIError
+from tap_shopify.exceptions import ShopifyError, ShopifyAPIError, ShopifyUnauthorizedError
 from tap_shopify.streams.base import shopify_error_handling, get_request_timeout
 
 REQUIRED_CONFIG_KEYS = ["shop"]
@@ -34,7 +34,10 @@ def initialize_shopify_client():
     shopify.Shop.set_timeout(get_request_timeout())
 
     # Shop.current() makes a call for shop details with provided shop and api_key
-    return shopify.Shop.current().attributes
+    try:
+        return shopify.Shop.current().attributes
+    except pyactiveresource.connection.UnauthorizedAccess as exc:
+        raise ShopifyUnauthorizedError(exc, "Invalid access token") from exc
 
 # Add helper
 def fetch_app_scopes():
@@ -220,16 +223,11 @@ def main():
         Context.config = args.config
         Context.state = args.state
 
-        dev_mode = args.dev
-        if dev_mode:
-            LOGGER.warning("Executing Tap in Dev mode")
-
-        if 'api_key' not in Context.config:
-            # Initialize the ShopifyClient for token management
+        if 'client_id' in Context.config:
+            # Initialize the ShopifyClient for token management (client credentials mode)
             Context.client = ShopifyClient(
                 config_path=args.config_path,
-                config=Context.config,
-                dev_mode=dev_mode
+                config=Context.config
             )
             Context.config['access_token'] = Context.client.access_token
 

--- a/tap_shopify/client.py
+++ b/tap_shopify/client.py
@@ -1,12 +1,12 @@
-from decimal import Context
 import json
-import time
 import datetime
 import backoff
 import requests
 import shopify
 import singer
+import urllib
 from tap_shopify.streams.base import get_request_timeout
+from tap_shopify.exceptions import ShopifyError
 
 LOGGER = singer.get_logger()
 
@@ -54,7 +54,8 @@ class ShopifyClient:
         buffer = datetime.timedelta(seconds=TOKEN_EXPIRY_BUFFER_SECONDS)
 
         if now >= (expires_at - buffer):
-            LOGGER.info("Access token expiring soon (expires_at: %s). Refreshing it now.", token_expires_at)
+            LOGGER.info("Access token expiring soon (expires_at: %s). Refreshing it now.",
+                        token_expires_at)
             return False
         return True
 
@@ -79,7 +80,8 @@ class ShopifyClient:
         response = requests.post(token_url, json=payload, timeout=30)
 
         if response.status_code != 200:
-            raise Exception(
+            raise ShopifyError(
+                urllib.error.HTTPError,
                 f"Failed to obtain access token. "
                 f"Status: {response.status_code}, Response: {response.text}"
             )
@@ -130,7 +132,6 @@ class ShopifyClient:
 
     def reinitialize_session(self):
         """Reinitialize the Shopify session with the current access token."""
-        
         session = shopify.Session(self.config['shop'], SHOPIFY_API_VERSION, self.access_token)
         shopify.ShopifyResource.activate_session(session)
 

--- a/tap_shopify/client.py
+++ b/tap_shopify/client.py
@@ -1,10 +1,10 @@
 import json
 import datetime
+import urllib
 import backoff
 import requests
 import shopify
 import singer
-import urllib
 from tap_shopify.streams.base import get_request_timeout
 from tap_shopify.exceptions import ShopifyError
 

--- a/tap_shopify/client.py
+++ b/tap_shopify/client.py
@@ -31,7 +31,7 @@ class ShopifyClient:
         self.config_path = config_path
         self.config = config
         self.dev_mode = dev_mode
-        self.access_token = config['access_token']
+        self.access_token = config.get('access_token')
 
         self.refresh_if_expired()
 
@@ -48,7 +48,7 @@ class ShopifyClient:
             expires_at = datetime.datetime.fromisoformat(token_expires_at)
         except (ValueError, TypeError):
             LOGGER.warning("Invalid 'access_token_expires_at': %s. Will refresh.", token_expires_at)
-            return True
+            return False
 
         now = datetime.datetime.now(datetime.timezone.utc)
         buffer = datetime.timedelta(seconds=TOKEN_EXPIRY_BUFFER_SECONDS)

--- a/tap_shopify/client.py
+++ b/tap_shopify/client.py
@@ -1,0 +1,139 @@
+from decimal import Context
+import json
+import time
+import datetime
+import backoff
+import requests
+import shopify
+import singer
+from tap_shopify.streams.base import get_request_timeout
+
+LOGGER = singer.get_logger()
+
+# Shopify client credentials tokens are valid for 24 hours
+TOKEN_VALIDITY_SECONDS = 86400
+
+# Refresh 30 minutes before actual expiry to avoid extraction interruptions.
+TOKEN_EXPIRY_BUFFER_SECONDS = 1800
+
+SHOPIFY_API_VERSION = '2025-07'
+
+class ShopifyClient:
+    """
+    Handles Shopify authentication via client credentials grant type.
+
+    - Manages access token lifecycle (expiry check, refresh)
+    - Saves refreshed tokens back to the config file
+    - Supports dev mode (uses existing token, never refreshes)
+    """
+
+    def __init__(self, config_path, config, dev_mode=False):
+        self.config_path = config_path
+        self.config = config
+        self.dev_mode = dev_mode
+        self.access_token = config['access_token']
+
+        self.refresh_if_expired()
+
+
+    def _is_token_valid(self):
+        """Check if the current access token is still valid (not expired)."""
+        token_expires_at = self.config.get('token_expires_at')
+
+        if not token_expires_at:
+            LOGGER.info("No 'token_expires_at' in config. Will refresh the access_token.")
+            return False
+
+        try:
+            expires_at = datetime.datetime.fromisoformat(token_expires_at)
+        except (ValueError, TypeError):
+            LOGGER.warning("Invalid 'access_token_expires_at': %s. Will refresh.", token_expires_at)
+            return True
+
+        now = datetime.datetime.now(datetime.timezone.utc)
+        buffer = datetime.timedelta(seconds=TOKEN_EXPIRY_BUFFER_SECONDS)
+
+        if now >= (expires_at - buffer):
+            LOGGER.info("Access token expiring soon (expires_at: %s). Refreshing it now.", token_expires_at)
+            return False
+        return True
+
+    @backoff.on_exception(backoff.expo,
+                          requests.exceptions.RequestException,
+                          max_tries=3,
+                          factor=2)
+    def _refresh_access_token(self):
+        """Generate a new access token using client credentials grant type."""
+        shop = self.config['shop']
+        client_id = self.config['client_id']
+        client_secret = self.config['client_secret']
+
+        token_url = f"https://{shop}.myshopify.com/admin/oauth/access_token"
+        payload = {
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "grant_type": "client_credentials"
+        }
+
+        LOGGER.info("Requesting new access token via client credentials grant")
+        response = requests.post(token_url, json=payload, timeout=30)
+
+        if response.status_code != 200:
+            raise Exception(
+                f"Failed to obtain access token. "
+                f"Status: {response.status_code}, Response: {response.text}"
+            )
+
+        token_data = response.json()
+        self.access_token = token_data['access_token']
+
+        # Calculate expiry: use expires_in from response or default to 24 hours
+        expires_in = token_data.get('expires_in', TOKEN_VALIDITY_SECONDS)
+        token_expires_at = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(
+            seconds=expires_in)
+
+        # Update config in memory
+        self.config['access_token'] = self.access_token
+        self.config['token_expires_at'] = token_expires_at.isoformat()
+
+        # Write back to config file
+        self._write_config()
+
+    def _write_config(self):
+        """Save updated config (with new token) back to config file."""
+        LOGGER.info("Saving credentials back to config")
+
+        with open(self.config_path, 'r', encoding='utf-8') as f:
+            config = json.load(f)
+
+        config['access_token'] = self.config['access_token']
+        config['token_expires_at'] = self.config['token_expires_at']
+
+        with open(self.config_path, 'w', encoding='utf-8') as f:
+            json.dump(config, f, indent=2)
+
+    def refresh_if_expired(self):
+        """
+        Check token expiry and refresh if needed.
+
+        Returns:
+            True if token was refreshed, False otherwise.
+        """
+        if self.dev_mode:
+            return False
+
+        if not self._is_token_valid():
+            self._refresh_access_token()
+            return True
+
+        return False
+
+    def reinitialize_session(self):
+        """Reinitialize the Shopify session with the current access token."""
+        
+        session = shopify.Session(self.config['shop'], SHOPIFY_API_VERSION, self.access_token)
+        shopify.ShopifyResource.activate_session(session)
+
+        # set request timeout
+        shopify.Shop.set_timeout(get_request_timeout())
+        LOGGER.info("Shopify session reinitialized with refreshed token")

--- a/tap_shopify/client.py
+++ b/tap_shopify/client.py
@@ -77,13 +77,31 @@ class ShopifyClient:
         }
 
         LOGGER.info("Requesting new access token via client credentials grant")
-        response = requests.post(token_url, json=payload, timeout=30)
+        response = requests.post(token_url, json=payload,
+                                 headers={"Accept": "application/json"},
+                                 timeout=30)
 
         if response.status_code != 200:
+            try:
+                error_data = response.json()
+                error_detail = (
+                    error_data.get('error_description')
+                    or error_data.get('error')
+                    or response.text
+                )
+            except Exception:
+                error_detail = response.text
+
             raise ShopifyError(
-                urllib.error.HTTPError,
+                urllib.error.HTTPError(
+                    url=token_url,
+                    code=response.status_code,
+                    msg=error_detail,
+                    hdrs={},
+                    fp=None
+                ),
                 f"Failed to obtain access token. "
-                f"Status: {response.status_code}, Response: {response.text}"
+                f"Status: {response.status_code}. {error_detail}"
             )
 
         token_data = response.json()

--- a/tap_shopify/client.py
+++ b/tap_shopify/client.py
@@ -1,5 +1,4 @@
 import json
-import datetime
 import urllib
 import backoff
 import requests
@@ -10,54 +9,25 @@ from tap_shopify.exceptions import ShopifyError
 
 LOGGER = singer.get_logger()
 
-# Shopify client credentials tokens are valid for 24 hours
-TOKEN_VALIDITY_SECONDS = 86400
-
-# Refresh 30 minutes before actual expiry to avoid extraction interruptions.
-TOKEN_EXPIRY_BUFFER_SECONDS = 1800
-
 SHOPIFY_API_VERSION = '2025-07'
 
 class ShopifyClient:
     """
     Handles Shopify authentication via client credentials grant type.
 
-    - Manages access token lifecycle (expiry check, refresh)
+    - Fetches an access token on startup if one is not already present
+    - Re-fetches the token when the API returns a 401 (token expired or revoked)
     - Saves refreshed tokens back to the config file
-    - Supports dev mode (uses existing token, never refreshes)
     """
 
-    def __init__(self, config_path, config, dev_mode=False):
+    def __init__(self, config_path, config):
         self.config_path = config_path
         self.config = config
-        self.dev_mode = dev_mode
         self.access_token = config.get('access_token')
 
-        self.refresh_if_expired()
+        if not self.access_token:
+            self._refresh_access_token()
 
-
-    def _is_token_valid(self):
-        """Check if the current access token is still valid (not expired)."""
-        token_expires_at = self.config.get('token_expires_at')
-
-        if not token_expires_at:
-            LOGGER.info("No 'token_expires_at' in config. Will refresh the access_token.")
-            return False
-
-        try:
-            expires_at = datetime.datetime.fromisoformat(token_expires_at)
-        except (ValueError, TypeError):
-            LOGGER.warning("Invalid 'access_token_expires_at': %s. Will refresh.", token_expires_at)
-            return False
-
-        now = datetime.datetime.now(datetime.timezone.utc)
-        buffer = datetime.timedelta(seconds=TOKEN_EXPIRY_BUFFER_SECONDS)
-
-        if now >= (expires_at - buffer):
-            LOGGER.info("Access token expiring soon (expires_at: %s). Refreshing it now.",
-                        token_expires_at)
-            return False
-        return True
 
     @backoff.on_exception(backoff.expo,
                           requests.exceptions.RequestException,
@@ -107,14 +77,8 @@ class ShopifyClient:
         token_data = response.json()
         self.access_token = token_data['access_token']
 
-        # Calculate expiry: use expires_in from response or default to 24 hours
-        expires_in = token_data.get('expires_in', TOKEN_VALIDITY_SECONDS)
-        token_expires_at = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(
-            seconds=expires_in)
-
         # Update config in memory
         self.config['access_token'] = self.access_token
-        self.config['token_expires_at'] = token_expires_at.isoformat()
 
         # Write back to config file
         self._write_config()
@@ -127,26 +91,13 @@ class ShopifyClient:
             config = json.load(f)
 
         config['access_token'] = self.config['access_token']
-        config['token_expires_at'] = self.config['token_expires_at']
 
         with open(self.config_path, 'w', encoding='utf-8') as f:
             json.dump(config, f, indent=2)
 
-    def refresh_if_expired(self):
-        """
-        Check token expiry and refresh if needed.
-
-        Returns:
-            True if token was refreshed, False otherwise.
-        """
-        if self.dev_mode:
-            return False
-
-        if not self._is_token_valid():
-            self._refresh_access_token()
-            return True
-
-        return False
+    def refresh_token(self):
+        """Force a token refresh. Called when the API returns a 401 (token expired or revoked)."""
+        self._refresh_access_token()
 
     def reinitialize_session(self):
         """Reinitialize the Shopify session with the current access token."""

--- a/tap_shopify/client.py
+++ b/tap_shopify/client.py
@@ -1,5 +1,5 @@
 import json
-import urllib
+import urllib.error
 import backoff
 import requests
 import shopify

--- a/tap_shopify/client.py
+++ b/tap_shopify/client.py
@@ -29,6 +29,7 @@ class ShopifyClient:
             self._refresh_access_token()
 
 
+    # pylint: disable=broad-exception-caught
     @backoff.on_exception(backoff.expo,
                           requests.exceptions.RequestException,
                           max_tries=3,

--- a/tap_shopify/context.py
+++ b/tap_shopify/context.py
@@ -10,6 +10,7 @@ class Context():
     stream_map = {}
     stream_objects = {}
     counts = {}
+    client = None  # ShopifyClient instance for token management
 
     @classmethod
     def get_catalog_entry(cls, stream_name):

--- a/tap_shopify/exceptions.py
+++ b/tap_shopify/exceptions.py
@@ -2,6 +2,10 @@ class ShopifyError(Exception):
     def __init__(self, error, msg=''):
         super().__init__('{}\n{}'.format(error.__class__.__name__, msg))
 
+class ShopifyUnauthorizedError(Exception):
+    def __init__(self, error, msg=''):
+        super().__init__('{}\n{}'.format(error.__class__.__name__, msg))
+
 class ShopifyAPIError(Exception):
     """Raised for any unexpected api error without a valid status code"""
 

--- a/tap_shopify/streams/base.py
+++ b/tap_shopify/streams/base.py
@@ -78,7 +78,8 @@ def leaky_bucket_handler(details):
 
 def retry_401_handler(_details):
     LOGGER.info("Received 401 Unauthorized - attempting token refresh and retry")
-    if Context.client.refresh_if_expired():
+    if Context.client:
+        Context.client.refresh_token()
         Context.client.reinitialize_session()
 
 def retry_handler(details):

--- a/tap_shopify/streams/base.py
+++ b/tap_shopify/streams/base.py
@@ -76,7 +76,7 @@ def leaky_bucket_handler(details):
     LOGGER.info("Received 429 -- sleeping for %s seconds",
                 details['wait'])
 
-def retry_401_handler(details):
+def retry_401_handler(_details):
     LOGGER.info("Received 401 Unauthorized - attempting token refresh and retry")
     if Context.client.refresh_if_expired():
         Context.client.reinitialize_session()
@@ -306,7 +306,7 @@ class Stream():
                     f"Unauthorized access - token may have expired with status {http_error.code} "
                     f"and X-Request-ID '{request_id or 'N/A'}', Reason: {error_message}."
                 ) from http_error
-           
+
             raise ShopifyError(http_error,
                 f"GraphQL request failed for stream '{self.name}' with status {http_error.code} "
                 f"and X-Request-ID '{request_id or 'N/A'}', Reason: {error_message}."

--- a/tap_shopify/streams/base.py
+++ b/tap_shopify/streams/base.py
@@ -77,10 +77,12 @@ def leaky_bucket_handler(details):
                 details['wait'])
 
 def retry_401_handler(_details):
-    LOGGER.info("Received 401 Unauthorized - attempting token refresh and retry")
     if Context.client:
+        LOGGER.info("Received 401 Unauthorized - attempting token refresh and retry")
         Context.client.refresh_token()
         Context.client.reinitialize_session()
+    else:
+        LOGGER.info("Received 401 Unauthorized - no client available for token refresh")
 
 def retry_handler(details):
     LOGGER.info("Received 500 or retryable error -- Retry %s/%s",

--- a/tap_shopify/streams/base.py
+++ b/tap_shopify/streams/base.py
@@ -16,7 +16,7 @@ from singer import metrics, utils
 from graphql import parse, print_ast, visit
 from graphql.language import Visitor, FieldNode, SelectionSetNode, OperationDefinitionNode, NameNode
 from tap_shopify.context import Context
-from tap_shopify.exceptions import ShopifyError, ShopifyAPIError
+from tap_shopify.exceptions import ShopifyError, ShopifyAPIError, ShopifyUnauthorizedError
 
 LOGGER = singer.get_logger()
 
@@ -76,6 +76,11 @@ def leaky_bucket_handler(details):
     LOGGER.info("Received 429 -- sleeping for %s seconds",
                 details['wait'])
 
+def retry_401_handler(details):
+    LOGGER.info("Received 401 Unauthorized - attempting token refresh and retry")
+    if Context.client.refresh_if_expired():
+        Context.client.reinitialize_session()
+
 def retry_handler(details):
     LOGGER.info("Received 500 or retryable error -- Retry %s/%s",
                 details['tries'], MAX_RETRIES)
@@ -115,6 +120,10 @@ def shopify_error_handling(fnc):
                           giveup=is_not_status_code_fn([404]),
                           on_backoff=retry_handler,
                           max_tries=MAX_RETRIES)
+    @backoff.on_exception(backoff.expo,
+                          ShopifyUnauthorizedError,
+                          on_backoff=retry_401_handler,
+                          max_tries=2)  # Only retry once on 401 for refreshing token
     @backoff.on_exception(backoff.expo,
                           pyactiveresource.connection.ClientError,
                           giveup=is_not_status_code_fn([429]),
@@ -292,6 +301,12 @@ class Stream():
                 if error_body
                 else http_error.reason
             )
+            if http_error.code == 401:
+                raise ShopifyUnauthorizedError(http_error,
+                    f"Unauthorized access - token may have expired with status {http_error.code} "
+                    f"and X-Request-ID '{request_id or 'N/A'}', Reason: {error_message}."
+                ) from http_error
+           
             raise ShopifyError(http_error,
                 f"GraphQL request failed for stream '{self.name}' with status {http_error.code} "
                 f"and X-Request-ID '{request_id or 'N/A'}', Reason: {error_message}."

--- a/tap_shopify/streams/orders.py
+++ b/tap_shopify/streams/orders.py
@@ -1052,7 +1052,10 @@ class Orders(Stream):
         url = f"https://{Context.config.get('shop')}.myshopify.com/admin/api/2025-07/graphql.json"
         headers = {
             "Content-Type": "application/json",
-            "X-Shopify-Access-Token": Context.config.get("access_token") or Context.config.get("api_key"),
+            "X-Shopify-Access-Token": (
+                Context.config.get("access_token")
+                or Context.config.get("api_key")
+            ),
         }
         operation = {
             "query": """

--- a/tap_shopify/streams/orders.py
+++ b/tap_shopify/streams/orders.py
@@ -1052,7 +1052,7 @@ class Orders(Stream):
         url = f"https://{Context.config.get('shop')}.myshopify.com/admin/api/2025-07/graphql.json"
         headers = {
             "Content-Type": "application/json",
-            "X-Shopify-Access-Token": Context.config.get("api_key"),
+            "X-Shopify-Access-Token": Context.config.get("access_token") or Context.config.get("api_key"),
         }
         operation = {
             "query": """

--- a/tests/base.py
+++ b/tests/base.py
@@ -38,16 +38,15 @@ class BaseTapTest(BaseCase):
     def get_type():
         """the expected url route ending"""
         # return "platform.shopify-tba"  # moved to alpha Oct 13, 2023
-        return "platform.shopify"        # new connections after Oct 13th
+        # return "platform.shopify"        # new connections after Oct 13th
+        return "platform.shopify-byoa"
 
     def get_properties(self, original: bool = True):
         """Configuration properties required for the tap."""
         return_value = {
             'start_date': '2017-07-01T00:00:00Z',
             'shop': 'stitchdatawearhouse',
-            'date_window_size': 180,
-            # BUG: https://jira.talendforge.org/browse/TDL-13180
-            # 'results_per_page': '50'
+            'date_window_size': 180
         }
 
         if original:
@@ -61,16 +60,12 @@ class BaseTapTest(BaseCase):
         return return_value
 
     @staticmethod
-    def get_credentials(original_credentials: bool = True):
+    def get_credentials():
         """Authentication information for the test account"""
 
-        if original_credentials:
-            return {
-                'api_key': os.getenv('TAP_SHOPIFY_API_KEY_STITCHDATAWEARHOUSE')
-            }
-
         return {
-            'api_key': os.getenv('TAP_SHOPIFY_API_KEY_TALENDDATAWEARHOUSE')
+            'client_id': os.getenv('TAP_SHOPIFY_CLIENT_ID'),
+            'client_secret': os.getenv('TAP_SHOPIFY_CLIENT_SECRET')
         }
 
     def expected_metadata(self):

--- a/tests/base.py
+++ b/tests/base.py
@@ -60,7 +60,7 @@ class BaseTapTest(BaseCase):
         return return_value
 
     @staticmethod
-    def get_credentials():
+    def get_credentials(original_credentials=True):
         """Authentication information for the test account"""
 
         return {

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -32,14 +32,6 @@ class AllFieldsTest(BaseTapTest):
 
         return return_value
 
-    @staticmethod
-    def get_credentials(original_credentials: bool = True):
-        """Authentication information for the test account"""
-
-        return {
-            'api_key': os.getenv('TAP_SHOPIFY_API_KEY_TALENDDATAWEARHOUSE')
-        }
-
     def test_run(self):
         """
         Ensure running the tap with all streams and fields selected results in the

--- a/tests/test_start_date.py
+++ b/tests/test_start_date.py
@@ -41,12 +41,6 @@ class StartDateTest(BaseTapTest):
         return return_value
 
     @staticmethod
-    def get_credentials(original_credentials: bool = True):
-        return {
-            'api_key': os.getenv('TAP_SHOPIFY_API_KEY_TALENDDATAWEARHOUSE')
-        }
-
-    @staticmethod
     def name():
         return "tap_tester_shopify_start_date_test"
 

--- a/tests/unittests/test_client.py
+++ b/tests/unittests/test_client.py
@@ -1,6 +1,5 @@
 import json
 import os
-import datetime
 import tempfile
 import unittest
 from unittest.mock import patch, MagicMock
@@ -9,24 +8,10 @@ import requests
 
 from tap_shopify.client import (
     ShopifyClient,
-    TOKEN_VALIDITY_SECONDS,
-    TOKEN_EXPIRY_BUFFER_SECONDS,
     SHOPIFY_API_VERSION,
 )
 from tap_shopify.context import Context
 from tap_shopify.exceptions import ShopifyError
-
-def _iso_future(seconds=7200):
-    """Helper to generate an ISO timestamp in the future."""
-    return (datetime.datetime.now(datetime.timezone.utc)
-            + datetime.timedelta(seconds=seconds)).isoformat()
-
-
-def _iso_past(seconds=100):
-    """Helper to generate an ISO timestamp in the past."""
-    return (datetime.datetime.now(datetime.timezone.utc)
-            - datetime.timedelta(seconds=seconds)).isoformat()
-
 
 class TestShopifyClientInit(unittest.TestCase):
     """Tests for ShopifyClient initialization."""
@@ -37,7 +22,6 @@ class TestShopifyClientInit(unittest.TestCase):
             "client_id": "cid",
             "client_secret": "csecret",
             "access_token": "existing_token",
-            "token_expires_at": _iso_future(7200),
             "start_date": "2025-01-01T00:00:00Z",
         }
         base.update(overrides)
@@ -50,156 +34,36 @@ class TestShopifyClientInit(unittest.TestCase):
         tmp.close()
         return tmp.name
 
-    # -------------------------------------------------------------------------
-    # Dev mode tests
-    # -------------------------------------------------------------------------
-    def test_dev_mode_with_access_token(self):
-        """Dev mode should use existing access_token and not refresh."""
-        config = self._make_config()
+    @patch('tap_shopify.client.requests.post')
+    def test_init_uses_existing_token_without_refresh(self, mock_post):
+        """When an access_token is already in config, no refresh should be triggered."""
+        config = self._make_config()  # has access_token='existing_token'
         path = self._write_config_file(config)
         try:
-            client = ShopifyClient(path, config, dev_mode=True)
-            self.assertTrue(client.dev_mode)
+            client = ShopifyClient(path, config)
+            mock_post.assert_not_called()
             self.assertEqual(client.access_token, "existing_token")
         finally:
             os.unlink(path)
 
-    def test_dev_mode_without_access_token_raises(self):
-        """Dev mode without access_token should raise KeyError."""
+    @patch('tap_shopify.client.requests.post')
+    def test_init_fetches_token_when_missing(self, mock_post):
+        """First run: no access_token in config, should fetch one via client credentials."""
         config = self._make_config()
         del config['access_token']
         path = self._write_config_file(config)
         try:
-            with self.assertRaises(KeyError):
-                ShopifyClient(path, config, dev_mode=True)
-        finally:
-            os.unlink(path)
-
-    # -------------------------------------------------------------------------
-    # Non-dev mode — valid token
-    # -------------------------------------------------------------------------
-    def test_init_with_valid_token(self):
-        """If token is not expired, no refresh should occur."""
-        config = self._make_config(token_expires_at=_iso_future(7200))
-        path = self._write_config_file(config)
-        try:
-            with patch.object(ShopifyClient, '_refresh_access_token') as mock_refresh:
-                client = ShopifyClient(path, config, dev_mode=False)
-                mock_refresh.assert_not_called()
-                self.assertEqual(client.access_token, "existing_token")
-        finally:
-            os.unlink(path)
-
-    # -------------------------------------------------------------------------
-    # Non-dev mode — expired token triggers refresh
-    # -------------------------------------------------------------------------
-    @patch('tap_shopify.client.requests.post')
-    def test_init_with_expired_token_triggers_refresh(self, mock_post):
-        """Expired token should trigger a token refresh."""
-        config = self._make_config(token_expires_at=_iso_past(100))
-        path = self._write_config_file(config)
-        try:
             mock_post.return_value = MagicMock(
                 status_code=200,
-                json=MagicMock(return_value={
-                    "access_token": "new_token",
-                    "expires_in": TOKEN_VALIDITY_SECONDS,
-                }),
+                json=MagicMock(return_value={"access_token": "fetched_token"}),
             )
-            client = ShopifyClient(path, config, dev_mode=False)
+            client = ShopifyClient(path, config)
             mock_post.assert_called_once()
-            self.assertEqual(client.access_token, "new_token")
-            self.assertEqual(config['access_token'], "new_token")
+            self.assertEqual(client.access_token, "fetched_token")
+            self.assertEqual(config['access_token'], "fetched_token")
         finally:
             os.unlink(path)
 
-    @patch('tap_shopify.client.requests.post')
-    def test_init_calls_refresh_if_expired(self, mock_post):
-        """__init__ should call refresh_if_expired on construction."""
-        config = self._make_config(token_expires_at=_iso_past(100))
-        path = self._write_config_file(config)
-        try:
-            mock_post.return_value = MagicMock(
-                status_code=200,
-                json=MagicMock(return_value={
-                    "access_token": "refreshed",
-                    "expires_in": TOKEN_VALIDITY_SECONDS,
-                }),
-            )
-            with patch.object(ShopifyClient, 'refresh_if_expired', return_value=True) as mock_rfe:
-                client = ShopifyClient(path, config, dev_mode=False)
-                mock_rfe.assert_called_once()
-        finally:
-            os.unlink(path)
-
-
-class TestIsTokenValid(unittest.TestCase):
-    """Tests for ShopifyClient._is_token_valid."""
-
-    def _create_client_skip_init(self, config):
-        """Create a client instance bypassing __init__ to test individual methods."""
-        client = object.__new__(ShopifyClient)
-        client.config = config
-        client.dev_mode = False
-        client.config_path = "/tmp/dummy.json"
-        return client
-
-    def test_valid_token(self):
-        """Token expiring well in the future should be valid."""
-        config = {
-            "access_token": "tok",
-            "token_expires_at": _iso_future(7200),
-        }
-        client = self._create_client_skip_init(config)
-        self.assertTrue(client._is_token_valid())
-
-    def test_expired_token(self):
-        """Token that expired in the past should be invalid."""
-        config = {
-            "access_token": "tok",
-            "token_expires_at": _iso_past(100),
-        }
-        client = self._create_client_skip_init(config)
-        self.assertFalse(client._is_token_valid())
-
-    def test_token_within_buffer_is_invalid(self):
-        """Token expiring within the buffer window should be treated as invalid."""
-        config = {
-            "access_token": "tok",
-            "token_expires_at": _iso_future(TOKEN_EXPIRY_BUFFER_SECONDS - 10),
-        }
-        client = self._create_client_skip_init(config)
-        self.assertFalse(client._is_token_valid())
-
-    def test_token_outside_buffer_is_valid(self):
-        """Token expiring well beyond the buffer should be valid."""
-        config = {
-            "access_token": "tok",
-            "token_expires_at": _iso_future(TOKEN_EXPIRY_BUFFER_SECONDS + 100),
-        }
-        client = self._create_client_skip_init(config)
-        self.assertTrue(client._is_token_valid())
-
-    def test_missing_token_expires_at_returns_false(self):
-        """Missing token_expires_at should return False (triggers refresh)."""
-        config = {"access_token": "tok"}
-        client = self._create_client_skip_init(config)
-        self.assertFalse(client._is_token_valid())
-
-    def test_invalid_format_returns_true(self):
-        """Invalid token_expires_at format should return True (logs warning, no refresh)."""
-        config = {
-            "access_token": "tok",
-            "token_expires_at": "not-a-valid-date",
-        }
-        client = self._create_client_skip_init(config)
-        self.assertTrue(client._is_token_valid())
-
-    def test_none_token_expires_at_returns_false(self):
-        """Explicit None token_expires_at should return False."""
-        config = {"access_token": "tok", "token_expires_at": None}
-        client = self._create_client_skip_init(config)
-        self.assertFalse(client._is_token_valid())
 
 
 class TestRefreshAccessToken(unittest.TestCase):
@@ -209,7 +73,6 @@ class TestRefreshAccessToken(unittest.TestCase):
         client = object.__new__(ShopifyClient)
         client.config = config
         client.config_path = config_path
-        client.dev_mode = False
         return client
 
     @patch('tap_shopify.client.requests.post')
@@ -237,10 +100,6 @@ class TestRefreshAccessToken(unittest.TestCase):
 
             self.assertEqual(client.access_token, "refreshed_token")
             self.assertEqual(config['access_token'], "refreshed_token")
-            self.assertIn('token_expires_at', config)
-            # token_expires_at is now an ISO string; verify it parses to a future datetime
-            expires_at = datetime.datetime.fromisoformat(config['token_expires_at'])
-            self.assertGreater(expires_at, datetime.datetime.now(datetime.timezone.utc))
 
             # Verify the correct endpoint was called (shop + .myshopify.com)
             mock_post.assert_called_once_with(
@@ -250,47 +109,14 @@ class TestRefreshAccessToken(unittest.TestCase):
                     "client_secret": "csecret",
                     "grant_type": "client_credentials",
                 },
+                headers={"Accept": "application/json"},
                 timeout=30,
             )
 
-            # Verify config file was updated
+            # Verify config file was updated (access_token only, no expiry fields)
             with open(tmp.name, 'r') as f:
                 saved = json.load(f)
             self.assertEqual(saved['access_token'], "refreshed_token")
-            self.assertIn('token_expires_at', saved)
-        finally:
-            os.unlink(tmp.name)
-
-    @patch('tap_shopify.client.requests.post')
-    def test_refresh_uses_default_expiry_when_missing(self, mock_post):
-        """When expires_in is missing from response, use default 24h."""
-        config = {
-            "shop": "test-shop",
-            "client_id": "cid",
-            "client_secret": "csecret",
-        }
-        tmp = tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False)
-        json.dump(config, tmp)
-        tmp.close()
-
-        try:
-            client = self._create_client_skip_init(config, tmp.name)
-            mock_post.return_value = MagicMock(
-                status_code=200,
-                json=MagicMock(return_value={
-                    "access_token": "new_tok",
-                    # no expires_in
-                }),
-            )
-            before = datetime.datetime.now(datetime.timezone.utc)
-            client._refresh_access_token()
-            after = datetime.datetime.now(datetime.timezone.utc)
-
-            expires_at = datetime.datetime.fromisoformat(config['token_expires_at'])
-            expected_min = before + datetime.timedelta(seconds=TOKEN_VALIDITY_SECONDS)
-            expected_max = after + datetime.timedelta(seconds=TOKEN_VALIDITY_SECONDS)
-            self.assertGreaterEqual(expires_at, expected_min)
-            self.assertLessEqual(expires_at, expected_max)
         finally:
             os.unlink(tmp.name)
 
@@ -318,43 +144,12 @@ class TestRefreshAccessToken(unittest.TestCase):
         finally:
             os.unlink(tmp.name)
 
-    @patch('tap_shopify.client.requests.post')
-    def test_refresh_stores_iso_format_expiry(self, mock_post):
-        """token_expires_at should be stored as an ISO 8601 string."""
-        config = {
-            "shop": "test-shop",
-            "client_id": "cid",
-            "client_secret": "csecret",
-        }
-        tmp = tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False)
-        json.dump(config, tmp)
-        tmp.close()
-
-        try:
-            client = self._create_client_skip_init(config, tmp.name)
-            mock_post.return_value = MagicMock(
-                status_code=200,
-                json=MagicMock(return_value={
-                    "access_token": "tok",
-                    "expires_in": 3600,
-                }),
-            )
-            client._refresh_access_token()
-
-            # Verify it's a string, not a float
-            self.assertIsInstance(config['token_expires_at'], str)
-            # Verify it's valid ISO format
-            parsed = datetime.datetime.fromisoformat(config['token_expires_at'])
-            self.assertIsNotNone(parsed.tzinfo)
-        finally:
-            os.unlink(tmp.name)
-
 
 class TestWriteConfig(unittest.TestCase):
     """Tests for ShopifyClient._write_config."""
 
     def test_write_config_updates_file(self):
-        """Config file should be updated with new access_token and token_expires_at."""
+        """Config file should be updated with new access_token (token_expires_at not persisted)."""
         original = {
             "shop": "test-shop",
             "client_id": "cid",
@@ -365,17 +160,14 @@ class TestWriteConfig(unittest.TestCase):
         json.dump(original, tmp)
         tmp.close()
 
-        expires_iso = _iso_future(86400)
         try:
             config = {
                 **original,
                 "access_token": "new_token",
-                "token_expires_at": expires_iso,
             }
             client = object.__new__(ShopifyClient)
             client.config = config
             client.config_path = tmp.name
-            client.dev_mode = False
 
             client._write_config()
 
@@ -383,7 +175,7 @@ class TestWriteConfig(unittest.TestCase):
                 saved = json.load(f)
 
             self.assertEqual(saved['access_token'], "new_token")
-            self.assertEqual(saved['token_expires_at'], expires_iso)
+            self.assertNotIn('token_expires_at', saved)
             # Original keys preserved
             self.assertEqual(saved['shop'], "test-shop")
             self.assertEqual(saved['client_id'], "cid")
@@ -406,12 +198,10 @@ class TestWriteConfig(unittest.TestCase):
             config = {
                 **original,
                 "access_token": "tok",
-                "token_expires_at": _iso_future(86400),
             }
             client = object.__new__(ShopifyClient)
             client.config = config
             client.config_path = tmp.name
-            client.dev_mode = False
 
             client._write_config()
 
@@ -422,66 +212,18 @@ class TestWriteConfig(unittest.TestCase):
             os.unlink(tmp.name)
 
 
-class TestRefreshIfExpired(unittest.TestCase):
-    """Tests for ShopifyClient.refresh_if_expired."""
 
-    def _create_client_skip_init(self, config, dev_mode=False):
+class TestRefreshToken(unittest.TestCase):
+    """Tests for ShopifyClient.refresh_token (reactive 401 refresh)."""
+
+    @patch.object(ShopifyClient, '_refresh_access_token')
+    def test_refresh_token_calls_underlying_refresh(self, mock_refresh):
+        """refresh_token should always call _refresh_access_token."""
         client = object.__new__(ShopifyClient)
-        client.config = config
+        client.config = {"shop": "test-shop", "access_token": "tok"}
         client.config_path = "/tmp/dummy.json"
-        client.dev_mode = dev_mode
-        return client
-
-    def test_dev_mode_returns_false(self):
-        """Dev mode should never refresh."""
-        client = self._create_client_skip_init(
-            {"access_token": "tok", "token_expires_at": _iso_past(100)},
-            dev_mode=True,
-        )
-        result = client.refresh_if_expired()
-        self.assertFalse(result)
-
-    @patch.object(ShopifyClient, '_refresh_access_token')
-    def test_expired_token_triggers_refresh(self, mock_refresh):
-        """Expired token should trigger refresh and return True."""
-        client = self._create_client_skip_init({
-            "access_token": "tok",
-            "token_expires_at": _iso_past(100),
-        })
-        result = client.refresh_if_expired()
-        self.assertTrue(result)
-        mock_refresh.assert_called_once()
-
-    @patch.object(ShopifyClient, '_refresh_access_token')
-    def test_valid_token_does_not_refresh(self, mock_refresh):
-        """Valid token should not trigger refresh and return False."""
-        client = self._create_client_skip_init({
-            "access_token": "tok",
-            "token_expires_at": _iso_future(7200),
-        })
-        result = client.refresh_if_expired()
-        self.assertFalse(result)
-        mock_refresh.assert_not_called()
-
-    @patch.object(ShopifyClient, '_refresh_access_token')
-    def test_token_in_buffer_triggers_refresh(self, mock_refresh):
-        """Token within the expiry buffer should trigger refresh."""
-        client = self._create_client_skip_init({
-            "access_token": "tok",
-            "token_expires_at": _iso_future(TOKEN_EXPIRY_BUFFER_SECONDS - 10),
-        })
-        result = client.refresh_if_expired()
-        self.assertTrue(result)
-        mock_refresh.assert_called_once()
-
-    @patch.object(ShopifyClient, '_refresh_access_token')
-    def test_missing_token_expires_at_triggers_refresh(self, mock_refresh):
-        """Missing token_expires_at should trigger refresh."""
-        client = self._create_client_skip_init({
-            "access_token": "tok",
-        })
-        result = client.refresh_if_expired()
-        self.assertTrue(result)
+        client.access_token = "tok"
+        client.refresh_token()
         mock_refresh.assert_called_once()
 
 
@@ -496,7 +238,6 @@ class TestReinitializeSession(unittest.TestCase):
         client = object.__new__(ShopifyClient)
         client.config = {"shop": "test-shop"}
         client.access_token = "my_token"
-        client.dev_mode = False
         client.config_path = "/tmp/dummy.json"
 
         mock_session_instance = MagicMock()
@@ -523,44 +264,24 @@ class TestRetry401Handler(unittest.TestCase):
         Context.client = self.original_client
 
     def test_retry_401_handler_refreshes_and_reinitializes(self):
-        """retry_401_handler should call refresh_if_expired and reinitialize_session when refresh occurs."""
+        """retry_401_handler should call refresh_token and reinitialize_session."""
         from tap_shopify.streams.base import retry_401_handler
 
         mock_client = MagicMock()
-        mock_client.refresh_if_expired.return_value = True
         Context.client = mock_client
 
         retry_401_handler({'wait': 1, 'tries': 1})
 
-        mock_client.refresh_if_expired.assert_called_once()
+        mock_client.refresh_token.assert_called_once()
         mock_client.reinitialize_session.assert_called_once()
 
-    def test_retry_401_handler_no_reinitialize_when_not_refreshed(self):
-        """retry_401_handler should not reinitialize if refresh_if_expired returns False."""
+    def test_retry_401_handler_no_client(self):
+        """retry_401_handler should do nothing if Context.client is None."""
         from tap_shopify.streams.base import retry_401_handler
 
-        mock_client = MagicMock()
-        mock_client.refresh_if_expired.return_value = False
-        Context.client = mock_client
-
+        Context.client = None
+        # Should not raise
         retry_401_handler({'wait': 1, 'tries': 1})
-
-        mock_client.refresh_if_expired.assert_called_once()
-        mock_client.reinitialize_session.assert_not_called()
-
-    def test_retry_401_handler_dev_mode_does_not_refresh(self):
-        """In dev mode, refresh_if_expired returns False so no reinitialize should happen."""
-        from tap_shopify.streams.base import retry_401_handler
-
-        mock_client = MagicMock()
-        # In dev mode, refresh_if_expired returns False
-        mock_client.refresh_if_expired.return_value = False
-        Context.client = mock_client
-
-        retry_401_handler({'wait': 1, 'tries': 1})
-
-        mock_client.refresh_if_expired.assert_called_once()
-        mock_client.reinitialize_session.assert_not_called()
 
 
 class TestCallApiWithTokenRefresh(unittest.TestCase):
@@ -654,7 +375,7 @@ class TestCallApiWithTokenRefresh(unittest.TestCase):
 
         # Must provide a mock client so the retry_401_handler doesn't blow up
         mock_client = MagicMock()
-        mock_client.refresh_if_expired.return_value = False
+        mock_client.refresh_token.return_value = False
         Context.client = mock_client
 
         http_error = urllib.error.HTTPError(
@@ -672,86 +393,8 @@ class TestCallApiWithTokenRefresh(unittest.TestCase):
             stream.call_api({"query": "test", "first": 10})
 
 
-class TestMainDevMode(unittest.TestCase):
-    """Tests for dev mode flag in main()."""
-
-    @patch('tap_shopify.ShopifyClient')
-    @patch('tap_shopify.discover')
-    @patch('singer.utils.parse_args')
-    def test_main_passes_dev_mode_to_client(self, mock_parse_args, mock_discover, mock_client_cls):
-        """main() should pass dev mode flag to ShopifyClient."""
-        from tap_shopify import main
-
-        mock_args = MagicMock()
-        mock_args.config = {
-            "shop": "test-shop",
-            "client_id": "cid",
-            "client_secret": "csecret",
-            "access_token": "tok",
-            "token_expires_at": _iso_future(7200),
-            "start_date": "2025-01-01T00:00:00Z",
-        }
-        mock_args.state = {}
-        mock_args.dev = True
-        mock_args.discover = True
-        mock_args.config_path = "/tmp/config.json"
-        mock_args.catalog = None
-        mock_parse_args.return_value = mock_args
-
-        mock_client_instance = MagicMock()
-        mock_client_instance.access_token = "tok"
-        mock_client_cls.return_value = mock_client_instance
-        mock_discover.return_value = {"streams": []}
-
-        try:
-            main()
-        except SystemExit:
-            pass
-
-        mock_client_cls.assert_called_once_with(
-            config_path="/tmp/config.json",
-            config=mock_args.config,
-            dev_mode=True,
-        )
-
-    @patch('tap_shopify.ShopifyClient')
-    @patch('tap_shopify.discover')
-    @patch('singer.utils.parse_args')
-    def test_main_no_dev_mode(self, mock_parse_args, mock_discover, mock_client_cls):
-        """main() should pass dev_mode=False when --dev is not set."""
-        from tap_shopify import main
-
-        mock_args = MagicMock()
-        mock_args.config = {
-            "shop": "test-shop",
-            "client_id": "cid",
-            "client_secret": "csecret",
-            "access_token": "tok",
-            "token_expires_at": _iso_future(7200),
-            "start_date": "2025-01-01T00:00:00Z",
-        }
-        mock_args.state = {}
-        mock_args.dev = False
-        mock_args.discover = True
-        mock_args.config_path = "/tmp/config.json"
-        mock_args.catalog = None
-        mock_parse_args.return_value = mock_args
-
-        mock_client_instance = MagicMock()
-        mock_client_instance.access_token = "tok"
-        mock_client_cls.return_value = mock_client_instance
-        mock_discover.return_value = {"streams": []}
-
-        try:
-            main()
-        except SystemExit:
-            pass
-
-        mock_client_cls.assert_called_once_with(
-            config_path="/tmp/config.json",
-            config=mock_args.config,
-            dev_mode=False,
-        )
+class TestMainClient(unittest.TestCase):
+    """Tests for ShopifyClient wiring in main()."""
 
     @patch('tap_shopify.ShopifyClient')
     @patch('tap_shopify.discover')
@@ -766,7 +409,6 @@ class TestMainDevMode(unittest.TestCase):
             "client_id": "cid",
             "client_secret": "csecret",
             "access_token": "tok",
-            "token_expires_at": _iso_future(7200),
             "start_date": "2025-01-01T00:00:00Z",
         }
         mock_args.state = {}
@@ -790,8 +432,8 @@ class TestMainDevMode(unittest.TestCase):
 
     @patch('tap_shopify.discover')
     @patch('singer.utils.parse_args')
-    def test_main_no_client_when_no_access_token(self, mock_parse_args, mock_discover):
-        """main() should NOT create ShopifyClient when access_token is not in config."""
+    def test_main_no_client_when_api_key_present(self, mock_parse_args, mock_discover):
+        """main() should NOT create ShopifyClient when api_key is in config (legacy auth)."""
         from tap_shopify import main
 
         mock_args = MagicMock()
@@ -801,7 +443,6 @@ class TestMainDevMode(unittest.TestCase):
             "start_date": "2025-01-01T00:00:00Z",
         }
         mock_args.state = {}
-        mock_args.dev = False
         mock_args.discover = True
         mock_args.config_path = "/tmp/config.json"
         mock_args.catalog = None
@@ -832,7 +473,6 @@ class TestMainDevMode(unittest.TestCase):
             "client_id": "cid",
             "client_secret": "csecret",
             "access_token": "old_tok",
-            "token_expires_at": _iso_future(7200),
             "start_date": "2025-01-01T00:00:00Z",
         }
         mock_args.state = {}
@@ -874,7 +514,6 @@ class TestBackoffOnRefresh(unittest.TestCase):
             client = object.__new__(ShopifyClient)
             client.config = config
             client.config_path = tmp.name
-            client.dev_mode = False
 
             # Fail twice then succeed
             mock_post.side_effect = [
@@ -890,7 +529,7 @@ class TestBackoffOnRefresh(unittest.TestCase):
             ]
             client._refresh_access_token()
             self.assertEqual(client.access_token, "recovered_token")
-            self.assertEqual(mock_post.call_count, 3)
+            self.assertEqual(mock_post.call_count, 3)  # backoff retried twice then succeeded
         finally:
             os.unlink(tmp.name)
 
@@ -910,7 +549,6 @@ class TestBackoffOnRefresh(unittest.TestCase):
             client = object.__new__(ShopifyClient)
             client.config = config
             client.config_path = tmp.name
-            client.dev_mode = False
 
             mock_post.side_effect = requests.exceptions.ConnectionError("Connection refused")
 

--- a/tests/unittests/test_client.py
+++ b/tests/unittests/test_client.py
@@ -11,7 +11,7 @@ from tap_shopify.client import (
     SHOPIFY_API_VERSION,
 )
 from tap_shopify.context import Context
-from tap_shopify.exceptions import ShopifyError
+from tap_shopify.exceptions import ShopifyError, ShopifyUnauthorizedError
 
 class TestShopifyClientInit(unittest.TestCase):
     """Tests for ShopifyClient initialization."""
@@ -283,6 +283,57 @@ class TestRetry401Handler(unittest.TestCase):
         # Should not raise
         retry_401_handler({'wait': 1, 'tries': 1})
 
+    @patch('tap_shopify.client.requests.post')
+    def test_retry_401_handler_updates_context_config_access_token(self, mock_post):
+        """After retry_401_handler fires, Context.config['access_token'] must reflect
+        the newly fetched token.
+
+        This relies on ShopifyClient.config being the *same dict object* as
+        Context.config (passed by reference in main()), so that
+        _refresh_access_token()'s `self.config['access_token'] = ...`
+        is immediately visible via Context.config['access_token'].
+        """
+        import tempfile, os
+        from tap_shopify.streams.base import retry_401_handler
+
+        shared_config = {
+            "shop": "test-shop",
+            "client_id": "cid",
+            "client_secret": "csecret",
+            "access_token": "old_token",
+            "start_date": "2025-01-01T00:00:00Z",
+        }
+
+        tmp = tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False)
+        json.dump(shared_config, tmp)
+        tmp.close()
+
+        try:
+            # Wire up a real ShopifyClient sharing the same config dict as Context
+            client = object.__new__(ShopifyClient)
+            client.config = shared_config       # same object as Context.config below
+            client.config_path = tmp.name
+            client.access_token = "old_token"
+
+            Context.config = shared_config      # same dict reference
+            Context.client = client
+
+            mock_post.return_value = MagicMock(
+                status_code=200,
+                json=MagicMock(return_value={"access_token": "new_token"}),
+            )
+
+            with patch('shopify.Session'), \
+                 patch('shopify.ShopifyResource.activate_session'), \
+                 patch('shopify.Shop.set_timeout'):
+                retry_401_handler({'wait': 1, 'tries': 1})
+
+            # The token update in ShopifyClient must be visible through Context.config
+            self.assertEqual(Context.config['access_token'], "new_token")
+            self.assertEqual(client.access_token, "new_token")
+        finally:
+            os.unlink(tmp.name)
+
 
 class TestCallApiWithTokenRefresh(unittest.TestCase):
     """Tests for call_api behaviour regarding token handling."""
@@ -493,6 +544,93 @@ class TestMainClient(unittest.TestCase):
             pass
 
         self.assertEqual(Context.config.get('access_token'), "refreshed_tok")
+
+    def _make_discover_args(self, extra_config=None):
+        mock_args = MagicMock()
+        mock_args.config = {
+            "shop": "test-shop",
+            "client_id": "cid",
+            "client_secret": "csecret",
+            "access_token": "tok",
+            "start_date": "2025-01-01T00:00:00Z",
+        }
+        if extra_config:
+            mock_args.config.update(extra_config)
+        mock_args.state = {}
+        mock_args.dev = False
+        mock_args.discover = True
+        mock_args.config_path = "/tmp/config.json"
+        mock_args.catalog = None
+        return mock_args
+
+    @patch('tap_shopify.ShopifyClient')
+    @patch('tap_shopify.discover')
+    @patch('singer.utils.parse_args')
+    def test_main_propagates_shopify_unauthorized_error(
+        self, mock_parse_args, mock_discover, mock_client_cls
+    ):
+        """main() must re-raise ShopifyUnauthorizedError as-is, not wrap it in ShopifyError.
+
+        Before the fix, ShopifyUnauthorizedError fell into `except Exception` and was
+        re-raised as ShopifyError(exc) with an empty message, losing the original context.
+        After the fix, a dedicated `except ShopifyUnauthorizedError` branch re-raises it
+        directly so callers receive the correct type and message.
+        """
+        from tap_shopify import main
+
+        mock_parse_args.return_value = self._make_discover_args()
+
+        mock_client_instance = MagicMock()
+        mock_client_instance.access_token = "tok"
+        mock_client_cls.return_value = mock_client_instance
+
+        original_error = ShopifyUnauthorizedError(
+            Exception("UnauthorizedAccess"), "Invalid access token"
+        )
+        mock_discover.side_effect = original_error
+
+        with self.assertRaises(ShopifyUnauthorizedError) as ctx:
+            main()
+
+        # The exception must be the original instance (not a wrapped ShopifyError)
+        self.assertIsInstance(ctx.exception, ShopifyUnauthorizedError)
+        self.assertNotIsInstance(ctx.exception, ShopifyError)
+        self.assertIn("Invalid access token", str(ctx.exception))
+
+    @patch('tap_shopify.ShopifyClient')
+    @patch('tap_shopify.discover')
+    @patch('singer.utils.parse_args')
+    def test_main_unauthorized_error_message_preserved(
+        self, mock_parse_args, mock_discover, mock_client_cls
+    ):
+        """ShopifyUnauthorizedError message must survive propagation through main().
+
+        Previously the message was lost because the error was caught by the generic
+        `except Exception` handler and re-raised as ShopifyError(exc, msg='').
+        """
+        from tap_shopify import main
+
+        mock_parse_args.return_value = self._make_discover_args()
+
+        mock_client_instance = MagicMock()
+        mock_client_instance.access_token = "tok"
+        mock_client_cls.return_value = mock_client_instance
+
+        expected_message = "Invalid access token"
+        mock_discover.side_effect = ShopifyUnauthorizedError(
+            Exception("UnauthorizedAccess"), expected_message
+        )
+
+        try:
+            main()
+            self.fail("Expected ShopifyUnauthorizedError to be raised")
+        except ShopifyUnauthorizedError as exc:
+            self.assertIn(expected_message, str(exc))
+        except ShopifyError:
+            self.fail(
+                "ShopifyUnauthorizedError was incorrectly wrapped as ShopifyError, "
+                "losing the original message"
+            )
 
 
 class TestBackoffOnRefresh(unittest.TestCase):

--- a/tests/unittests/test_client.py
+++ b/tests/unittests/test_client.py
@@ -1,0 +1,928 @@
+import json
+import os
+import time
+import datetime
+import tempfile
+import unittest
+from unittest.mock import patch, MagicMock, mock_open, call
+
+import requests
+
+from tap_shopify.client import (
+    ShopifyClient,
+    TOKEN_VALIDITY_SECONDS,
+    TOKEN_EXPIRY_BUFFER_SECONDS,
+    SHOPIFY_API_VERSION,
+)
+from tap_shopify.context import Context
+
+
+def _iso_future(seconds=7200):
+    """Helper to generate an ISO timestamp in the future."""
+    return (datetime.datetime.now(datetime.timezone.utc)
+            + datetime.timedelta(seconds=seconds)).isoformat()
+
+
+def _iso_past(seconds=100):
+    """Helper to generate an ISO timestamp in the past."""
+    return (datetime.datetime.now(datetime.timezone.utc)
+            - datetime.timedelta(seconds=seconds)).isoformat()
+
+
+class TestShopifyClientInit(unittest.TestCase):
+    """Tests for ShopifyClient initialization."""
+
+    def _make_config(self, **overrides):
+        base = {
+            "shop": "test-shop",
+            "client_id": "cid",
+            "client_secret": "csecret",
+            "access_token": "existing_token",
+            "token_expires_at": _iso_future(7200),
+            "start_date": "2025-01-01T00:00:00Z",
+        }
+        base.update(overrides)
+        return base
+
+    def _write_config_file(self, config):
+        """Write config dict to a temp file and return its path."""
+        tmp = tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False)
+        json.dump(config, tmp)
+        tmp.close()
+        return tmp.name
+
+    # -------------------------------------------------------------------------
+    # Dev mode tests
+    # -------------------------------------------------------------------------
+    def test_dev_mode_with_access_token(self):
+        """Dev mode should use existing access_token and not refresh."""
+        config = self._make_config()
+        path = self._write_config_file(config)
+        try:
+            client = ShopifyClient(path, config, dev_mode=True)
+            self.assertTrue(client.dev_mode)
+            self.assertEqual(client.access_token, "existing_token")
+        finally:
+            os.unlink(path)
+
+    def test_dev_mode_without_access_token_raises(self):
+        """Dev mode without access_token should raise KeyError."""
+        config = self._make_config()
+        del config['access_token']
+        path = self._write_config_file(config)
+        try:
+            with self.assertRaises(KeyError):
+                ShopifyClient(path, config, dev_mode=True)
+        finally:
+            os.unlink(path)
+
+    # -------------------------------------------------------------------------
+    # Non-dev mode — valid token
+    # -------------------------------------------------------------------------
+    def test_init_with_valid_token(self):
+        """If token is not expired, no refresh should occur."""
+        config = self._make_config(token_expires_at=_iso_future(7200))
+        path = self._write_config_file(config)
+        try:
+            with patch.object(ShopifyClient, '_refresh_access_token') as mock_refresh:
+                client = ShopifyClient(path, config, dev_mode=False)
+                mock_refresh.assert_not_called()
+                self.assertEqual(client.access_token, "existing_token")
+        finally:
+            os.unlink(path)
+
+    # -------------------------------------------------------------------------
+    # Non-dev mode — expired token triggers refresh
+    # -------------------------------------------------------------------------
+    @patch('tap_shopify.client.requests.post')
+    def test_init_with_expired_token_triggers_refresh(self, mock_post):
+        """Expired token should trigger a token refresh."""
+        config = self._make_config(token_expires_at=_iso_past(100))
+        path = self._write_config_file(config)
+        try:
+            mock_post.return_value = MagicMock(
+                status_code=200,
+                json=MagicMock(return_value={
+                    "access_token": "new_token",
+                    "expires_in": TOKEN_VALIDITY_SECONDS,
+                }),
+            )
+            client = ShopifyClient(path, config, dev_mode=False)
+            mock_post.assert_called_once()
+            self.assertEqual(client.access_token, "new_token")
+            self.assertEqual(config['access_token'], "new_token")
+        finally:
+            os.unlink(path)
+
+    @patch('tap_shopify.client.requests.post')
+    def test_init_calls_refresh_if_expired(self, mock_post):
+        """__init__ should call refresh_if_expired on construction."""
+        config = self._make_config(token_expires_at=_iso_past(100))
+        path = self._write_config_file(config)
+        try:
+            mock_post.return_value = MagicMock(
+                status_code=200,
+                json=MagicMock(return_value={
+                    "access_token": "refreshed",
+                    "expires_in": TOKEN_VALIDITY_SECONDS,
+                }),
+            )
+            with patch.object(ShopifyClient, 'refresh_if_expired', return_value=True) as mock_rfe:
+                client = ShopifyClient(path, config, dev_mode=False)
+                mock_rfe.assert_called_once()
+        finally:
+            os.unlink(path)
+
+
+class TestIsTokenValid(unittest.TestCase):
+    """Tests for ShopifyClient._is_token_valid."""
+
+    def _create_client_skip_init(self, config):
+        """Create a client instance bypassing __init__ to test individual methods."""
+        client = object.__new__(ShopifyClient)
+        client.config = config
+        client.dev_mode = False
+        client.config_path = "/tmp/dummy.json"
+        return client
+
+    def test_valid_token(self):
+        """Token expiring well in the future should be valid."""
+        config = {
+            "access_token": "tok",
+            "token_expires_at": _iso_future(7200),
+        }
+        client = self._create_client_skip_init(config)
+        self.assertTrue(client._is_token_valid())
+
+    def test_expired_token(self):
+        """Token that expired in the past should be invalid."""
+        config = {
+            "access_token": "tok",
+            "token_expires_at": _iso_past(100),
+        }
+        client = self._create_client_skip_init(config)
+        self.assertFalse(client._is_token_valid())
+
+    def test_token_within_buffer_is_invalid(self):
+        """Token expiring within the buffer window should be treated as invalid."""
+        config = {
+            "access_token": "tok",
+            "token_expires_at": _iso_future(TOKEN_EXPIRY_BUFFER_SECONDS - 10),
+        }
+        client = self._create_client_skip_init(config)
+        self.assertFalse(client._is_token_valid())
+
+    def test_token_outside_buffer_is_valid(self):
+        """Token expiring well beyond the buffer should be valid."""
+        config = {
+            "access_token": "tok",
+            "token_expires_at": _iso_future(TOKEN_EXPIRY_BUFFER_SECONDS + 100),
+        }
+        client = self._create_client_skip_init(config)
+        self.assertTrue(client._is_token_valid())
+
+    def test_missing_token_expires_at_returns_false(self):
+        """Missing token_expires_at should return False (triggers refresh)."""
+        config = {"access_token": "tok"}
+        client = self._create_client_skip_init(config)
+        self.assertFalse(client._is_token_valid())
+
+    def test_invalid_format_returns_true(self):
+        """Invalid token_expires_at format should return True (logs warning, no refresh)."""
+        config = {
+            "access_token": "tok",
+            "token_expires_at": "not-a-valid-date",
+        }
+        client = self._create_client_skip_init(config)
+        self.assertTrue(client._is_token_valid())
+
+    def test_none_token_expires_at_returns_false(self):
+        """Explicit None token_expires_at should return False."""
+        config = {"access_token": "tok", "token_expires_at": None}
+        client = self._create_client_skip_init(config)
+        self.assertFalse(client._is_token_valid())
+
+
+class TestRefreshAccessToken(unittest.TestCase):
+    """Tests for ShopifyClient._refresh_access_token."""
+
+    def _create_client_skip_init(self, config, config_path="/tmp/dummy.json"):
+        client = object.__new__(ShopifyClient)
+        client.config = config
+        client.config_path = config_path
+        client.dev_mode = False
+        return client
+
+    @patch('tap_shopify.client.requests.post')
+    def test_successful_refresh(self, mock_post):
+        """Successful token refresh should update config and access_token."""
+        config = {
+            "shop": "test-shop",
+            "client_id": "cid",
+            "client_secret": "csecret",
+        }
+        tmp = tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False)
+        json.dump(config, tmp)
+        tmp.close()
+
+        try:
+            client = self._create_client_skip_init(config, tmp.name)
+            mock_post.return_value = MagicMock(
+                status_code=200,
+                json=MagicMock(return_value={
+                    "access_token": "refreshed_token",
+                    "expires_in": 86400,
+                }),
+            )
+            client._refresh_access_token()
+
+            self.assertEqual(client.access_token, "refreshed_token")
+            self.assertEqual(config['access_token'], "refreshed_token")
+            self.assertIn('token_expires_at', config)
+            # token_expires_at is now an ISO string; verify it parses to a future datetime
+            expires_at = datetime.datetime.fromisoformat(config['token_expires_at'])
+            self.assertGreater(expires_at, datetime.datetime.now(datetime.timezone.utc))
+
+            # Verify the correct endpoint was called (shop + .myshopify.com)
+            mock_post.assert_called_once_with(
+                "https://test-shop.myshopify.com/admin/oauth/access_token",
+                json={
+                    "client_id": "cid",
+                    "client_secret": "csecret",
+                    "grant_type": "client_credentials",
+                },
+                timeout=30,
+            )
+
+            # Verify config file was updated
+            with open(tmp.name, 'r') as f:
+                saved = json.load(f)
+            self.assertEqual(saved['access_token'], "refreshed_token")
+            self.assertIn('token_expires_at', saved)
+        finally:
+            os.unlink(tmp.name)
+
+    @patch('tap_shopify.client.requests.post')
+    def test_refresh_uses_default_expiry_when_missing(self, mock_post):
+        """When expires_in is missing from response, use default 24h."""
+        config = {
+            "shop": "test-shop",
+            "client_id": "cid",
+            "client_secret": "csecret",
+        }
+        tmp = tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False)
+        json.dump(config, tmp)
+        tmp.close()
+
+        try:
+            client = self._create_client_skip_init(config, tmp.name)
+            mock_post.return_value = MagicMock(
+                status_code=200,
+                json=MagicMock(return_value={
+                    "access_token": "new_tok",
+                    # no expires_in
+                }),
+            )
+            before = datetime.datetime.now(datetime.timezone.utc)
+            client._refresh_access_token()
+            after = datetime.datetime.now(datetime.timezone.utc)
+
+            expires_at = datetime.datetime.fromisoformat(config['token_expires_at'])
+            expected_min = before + datetime.timedelta(seconds=TOKEN_VALIDITY_SECONDS)
+            expected_max = after + datetime.timedelta(seconds=TOKEN_VALIDITY_SECONDS)
+            self.assertGreaterEqual(expires_at, expected_min)
+            self.assertLessEqual(expires_at, expected_max)
+        finally:
+            os.unlink(tmp.name)
+
+    @patch('tap_shopify.client.requests.post')
+    def test_refresh_failure_raises(self, mock_post):
+        """Non-200 response from token endpoint should raise."""
+        config = {
+            "shop": "test-shop",
+            "client_id": "cid",
+            "client_secret": "csecret",
+        }
+        tmp = tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False)
+        json.dump(config, tmp)
+        tmp.close()
+
+        try:
+            client = self._create_client_skip_init(config, tmp.name)
+            mock_post.return_value = MagicMock(
+                status_code=401,
+                text="Unauthorized",
+            )
+            with self.assertRaises(Exception) as ctx:
+                client._refresh_access_token()
+            self.assertIn("Failed to obtain access token", str(ctx.exception))
+        finally:
+            os.unlink(tmp.name)
+
+    @patch('tap_shopify.client.requests.post')
+    def test_refresh_stores_iso_format_expiry(self, mock_post):
+        """token_expires_at should be stored as an ISO 8601 string."""
+        config = {
+            "shop": "test-shop",
+            "client_id": "cid",
+            "client_secret": "csecret",
+        }
+        tmp = tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False)
+        json.dump(config, tmp)
+        tmp.close()
+
+        try:
+            client = self._create_client_skip_init(config, tmp.name)
+            mock_post.return_value = MagicMock(
+                status_code=200,
+                json=MagicMock(return_value={
+                    "access_token": "tok",
+                    "expires_in": 3600,
+                }),
+            )
+            client._refresh_access_token()
+
+            # Verify it's a string, not a float
+            self.assertIsInstance(config['token_expires_at'], str)
+            # Verify it's valid ISO format
+            parsed = datetime.datetime.fromisoformat(config['token_expires_at'])
+            self.assertIsNotNone(parsed.tzinfo)
+        finally:
+            os.unlink(tmp.name)
+
+
+class TestWriteConfig(unittest.TestCase):
+    """Tests for ShopifyClient._write_config."""
+
+    def test_write_config_updates_file(self):
+        """Config file should be updated with new access_token and token_expires_at."""
+        original = {
+            "shop": "test-shop",
+            "client_id": "cid",
+            "client_secret": "csecret",
+            "start_date": "2025-01-01T00:00:00Z",
+        }
+        tmp = tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False)
+        json.dump(original, tmp)
+        tmp.close()
+
+        expires_iso = _iso_future(86400)
+        try:
+            config = {
+                **original,
+                "access_token": "new_token",
+                "token_expires_at": expires_iso,
+            }
+            client = object.__new__(ShopifyClient)
+            client.config = config
+            client.config_path = tmp.name
+            client.dev_mode = False
+
+            client._write_config()
+
+            with open(tmp.name, 'r') as f:
+                saved = json.load(f)
+
+            self.assertEqual(saved['access_token'], "new_token")
+            self.assertEqual(saved['token_expires_at'], expires_iso)
+            # Original keys preserved
+            self.assertEqual(saved['shop'], "test-shop")
+            self.assertEqual(saved['client_id'], "cid")
+        finally:
+            os.unlink(tmp.name)
+
+    def test_write_config_preserves_extra_keys(self):
+        """Extra keys in the config file should not be removed."""
+        original = {
+            "shop": "test-shop",
+            "client_id": "cid",
+            "client_secret": "csecret",
+            "custom_setting": "keep_me",
+        }
+        tmp = tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False)
+        json.dump(original, tmp)
+        tmp.close()
+
+        try:
+            config = {
+                **original,
+                "access_token": "tok",
+                "token_expires_at": _iso_future(86400),
+            }
+            client = object.__new__(ShopifyClient)
+            client.config = config
+            client.config_path = tmp.name
+            client.dev_mode = False
+
+            client._write_config()
+
+            with open(tmp.name, 'r') as f:
+                saved = json.load(f)
+            self.assertEqual(saved['custom_setting'], "keep_me")
+        finally:
+            os.unlink(tmp.name)
+
+
+class TestRefreshIfExpired(unittest.TestCase):
+    """Tests for ShopifyClient.refresh_if_expired."""
+
+    def _create_client_skip_init(self, config, dev_mode=False):
+        client = object.__new__(ShopifyClient)
+        client.config = config
+        client.config_path = "/tmp/dummy.json"
+        client.dev_mode = dev_mode
+        return client
+
+    def test_dev_mode_returns_false(self):
+        """Dev mode should never refresh."""
+        client = self._create_client_skip_init(
+            {"access_token": "tok", "token_expires_at": _iso_past(100)},
+            dev_mode=True,
+        )
+        result = client.refresh_if_expired()
+        self.assertFalse(result)
+
+    @patch.object(ShopifyClient, '_refresh_access_token')
+    def test_expired_token_triggers_refresh(self, mock_refresh):
+        """Expired token should trigger refresh and return True."""
+        client = self._create_client_skip_init({
+            "access_token": "tok",
+            "token_expires_at": _iso_past(100),
+        })
+        result = client.refresh_if_expired()
+        self.assertTrue(result)
+        mock_refresh.assert_called_once()
+
+    @patch.object(ShopifyClient, '_refresh_access_token')
+    def test_valid_token_does_not_refresh(self, mock_refresh):
+        """Valid token should not trigger refresh and return False."""
+        client = self._create_client_skip_init({
+            "access_token": "tok",
+            "token_expires_at": _iso_future(7200),
+        })
+        result = client.refresh_if_expired()
+        self.assertFalse(result)
+        mock_refresh.assert_not_called()
+
+    @patch.object(ShopifyClient, '_refresh_access_token')
+    def test_token_in_buffer_triggers_refresh(self, mock_refresh):
+        """Token within the expiry buffer should trigger refresh."""
+        client = self._create_client_skip_init({
+            "access_token": "tok",
+            "token_expires_at": _iso_future(TOKEN_EXPIRY_BUFFER_SECONDS - 10),
+        })
+        result = client.refresh_if_expired()
+        self.assertTrue(result)
+        mock_refresh.assert_called_once()
+
+    @patch.object(ShopifyClient, '_refresh_access_token')
+    def test_missing_token_expires_at_triggers_refresh(self, mock_refresh):
+        """Missing token_expires_at should trigger refresh."""
+        client = self._create_client_skip_init({
+            "access_token": "tok",
+        })
+        result = client.refresh_if_expired()
+        self.assertTrue(result)
+        mock_refresh.assert_called_once()
+
+
+class TestReinitializeSession(unittest.TestCase):
+    """Tests for ShopifyClient.reinitialize_session."""
+
+    @patch('tap_shopify.client.shopify.Shop.set_timeout')
+    @patch('tap_shopify.client.shopify.ShopifyResource.activate_session')
+    @patch('tap_shopify.client.shopify.Session')
+    def test_reinitialize_session(self, mock_session_cls, mock_activate, mock_set_timeout):
+        """reinitialize_session should create a new session, activate it, and set timeout."""
+        client = object.__new__(ShopifyClient)
+        client.config = {"shop": "test-shop"}
+        client.access_token = "my_token"
+        client.dev_mode = False
+        client.config_path = "/tmp/dummy.json"
+
+        mock_session_instance = MagicMock()
+        mock_session_cls.return_value = mock_session_instance
+
+        client.reinitialize_session()
+
+        mock_session_cls.assert_called_once_with(
+            "test-shop",
+            SHOPIFY_API_VERSION,
+            "my_token",
+        )
+        mock_activate.assert_called_once_with(mock_session_instance)
+        mock_set_timeout.assert_called_once()
+
+
+class TestRetry401Handler(unittest.TestCase):
+    """Tests for the retry_401_handler function used in backoff decorator."""
+
+    def setUp(self):
+        self.original_client = Context.client
+
+    def tearDown(self):
+        Context.client = self.original_client
+
+    def test_retry_401_handler_refreshes_and_reinitializes(self):
+        """retry_401_handler should call refresh_if_expired and reinitialize_session when refresh occurs."""
+        from tap_shopify.streams.base import retry_401_handler
+
+        mock_client = MagicMock()
+        mock_client.refresh_if_expired.return_value = True
+        Context.client = mock_client
+
+        retry_401_handler({'wait': 1, 'tries': 1})
+
+        mock_client.refresh_if_expired.assert_called_once()
+        mock_client.reinitialize_session.assert_called_once()
+
+    def test_retry_401_handler_no_reinitialize_when_not_refreshed(self):
+        """retry_401_handler should not reinitialize if refresh_if_expired returns False."""
+        from tap_shopify.streams.base import retry_401_handler
+
+        mock_client = MagicMock()
+        mock_client.refresh_if_expired.return_value = False
+        Context.client = mock_client
+
+        retry_401_handler({'wait': 1, 'tries': 1})
+
+        mock_client.refresh_if_expired.assert_called_once()
+        mock_client.reinitialize_session.assert_not_called()
+
+    def test_retry_401_handler_dev_mode_does_not_refresh(self):
+        """In dev mode, refresh_if_expired returns False so no reinitialize should happen."""
+        from tap_shopify.streams.base import retry_401_handler
+
+        mock_client = MagicMock()
+        # In dev mode, refresh_if_expired returns False
+        mock_client.refresh_if_expired.return_value = False
+        Context.client = mock_client
+
+        retry_401_handler({'wait': 1, 'tries': 1})
+
+        mock_client.refresh_if_expired.assert_called_once()
+        mock_client.reinitialize_session.assert_not_called()
+
+
+class TestCallApiWithTokenRefresh(unittest.TestCase):
+    """Tests for call_api behaviour regarding token handling."""
+
+    def setUp(self):
+        self.original_config = Context.config
+        self.original_client = Context.client
+        Context.config = {
+            "start_date": "2025-01-01T00:00:00Z",
+            "date_window_size": 30,
+        }
+        Context.catalog = {
+            "streams": [{
+                "tap_stream_id": "products",
+                "schema": {"properties": {"id": {"type": "string"}, "updatedAt": {"type": "string"}}},
+                "metadata": [],
+            }],
+        }
+
+    def tearDown(self):
+        Context.config = self.original_config
+        Context.client = self.original_client
+
+    def _make_stream(self):
+        from tap_shopify.streams.base import Stream
+        stream = Stream()
+        stream.name = "products"
+        stream.data_key = "products"
+        return stream
+
+    @patch('shopify.GraphQL')
+    @patch('tap_shopify.streams.base.Stream.get_query', return_value='{ products { edges { node { id } } } }')
+    def test_call_api_success(self, mock_get_query, mock_graphql):
+        """call_api should return data on a successful GraphQL response."""
+        Context.client = None
+
+        mock_response = {
+            "data": {"products": {"edges": [], "pageInfo": {"endCursor": None, "hasNextPage": False}}}
+        }
+        mock_graphql.return_value.execute.return_value = json.dumps(mock_response)
+
+        stream = self._make_stream()
+        result = stream.call_api({"query": "test", "first": 10})
+        self.assertEqual(result, mock_response["data"]["products"])
+
+    @patch('shopify.GraphQL')
+    @patch('tap_shopify.streams.base.Stream.get_query', return_value='{ products { edges { node { id } } } }')
+    def test_call_api_without_client(self, mock_get_query, mock_graphql):
+        """call_api should work even if Context.client is None (backward compat)."""
+        Context.client = None
+
+        mock_response = {
+            "data": {"products": {"edges": [], "pageInfo": {"endCursor": None, "hasNextPage": False}}}
+        }
+        mock_graphql.return_value.execute.return_value = json.dumps(mock_response)
+
+        stream = self._make_stream()
+        result = stream.call_api({"query": "test", "first": 10})
+        self.assertEqual(result, mock_response["data"]["products"])
+
+    @patch('shopify.GraphQL')
+    @patch('tap_shopify.streams.base.Stream.get_query', return_value='{ products { edges { node { id } } } }')
+    def test_non_401_http_error_raises_shopify_error(self, mock_get_query, mock_graphql):
+        """Non-401 HTTPError should raise ShopifyError."""
+        import urllib.error
+        from tap_shopify.exceptions import ShopifyError
+
+        Context.client = None
+
+        http_error = urllib.error.HTTPError(
+            url="https://test-shop.myshopify.com/admin/api/graphql.json",
+            code=500,
+            msg="Internal Server Error",
+            hdrs=MagicMock(**{"get.return_value": "req-456"}),
+            fp=None,
+        )
+        mock_graphql.return_value.execute.side_effect = http_error
+
+        stream = self._make_stream()
+
+        with self.assertRaises(ShopifyError):
+            stream.call_api({"query": "test", "first": 10})
+
+    @patch('shopify.GraphQL')
+    @patch('tap_shopify.streams.base.Stream.get_query', return_value='{ products { edges { node { id } } } }')
+    def test_401_http_error_raises_shopify_unauthorized_error(self, mock_get_query, mock_graphql):
+        """401 HTTPError should raise ShopifyUnauthorizedError (not ShopifyError)."""
+        import urllib.error
+        from tap_shopify.exceptions import ShopifyUnauthorizedError
+
+        # Must provide a mock client so the retry_401_handler doesn't blow up
+        mock_client = MagicMock()
+        mock_client.refresh_if_expired.return_value = False
+        Context.client = mock_client
+
+        http_error = urllib.error.HTTPError(
+            url="https://test-shop.myshopify.com/admin/api/graphql.json",
+            code=401,
+            msg="Unauthorized",
+            hdrs=MagicMock(**{"get.return_value": "req-789"}),
+            fp=None,
+        )
+        mock_graphql.return_value.execute.side_effect = http_error
+
+        stream = self._make_stream()
+
+        with self.assertRaises(ShopifyUnauthorizedError):
+            stream.call_api({"query": "test", "first": 10})
+
+
+class TestMainDevMode(unittest.TestCase):
+    """Tests for dev mode flag in main()."""
+
+    @patch('tap_shopify.ShopifyClient')
+    @patch('tap_shopify.discover')
+    @patch('singer.utils.parse_args')
+    def test_main_passes_dev_mode_to_client(self, mock_parse_args, mock_discover, mock_client_cls):
+        """main() should pass dev mode flag to ShopifyClient."""
+        from tap_shopify import main
+
+        mock_args = MagicMock()
+        mock_args.config = {
+            "shop": "test-shop",
+            "client_id": "cid",
+            "client_secret": "csecret",
+            "access_token": "tok",
+            "token_expires_at": _iso_future(7200),
+            "start_date": "2025-01-01T00:00:00Z",
+        }
+        mock_args.state = {}
+        mock_args.dev = True
+        mock_args.discover = True
+        mock_args.config_path = "/tmp/config.json"
+        mock_args.catalog = None
+        mock_parse_args.return_value = mock_args
+
+        mock_client_instance = MagicMock()
+        mock_client_instance.access_token = "tok"
+        mock_client_cls.return_value = mock_client_instance
+        mock_discover.return_value = {"streams": []}
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        mock_client_cls.assert_called_once_with(
+            config_path="/tmp/config.json",
+            config=mock_args.config,
+            dev_mode=True,
+        )
+
+    @patch('tap_shopify.ShopifyClient')
+    @patch('tap_shopify.discover')
+    @patch('singer.utils.parse_args')
+    def test_main_no_dev_mode(self, mock_parse_args, mock_discover, mock_client_cls):
+        """main() should pass dev_mode=False when --dev is not set."""
+        from tap_shopify import main
+
+        mock_args = MagicMock()
+        mock_args.config = {
+            "shop": "test-shop",
+            "client_id": "cid",
+            "client_secret": "csecret",
+            "access_token": "tok",
+            "token_expires_at": _iso_future(7200),
+            "start_date": "2025-01-01T00:00:00Z",
+        }
+        mock_args.state = {}
+        mock_args.dev = False
+        mock_args.discover = True
+        mock_args.config_path = "/tmp/config.json"
+        mock_args.catalog = None
+        mock_parse_args.return_value = mock_args
+
+        mock_client_instance = MagicMock()
+        mock_client_instance.access_token = "tok"
+        mock_client_cls.return_value = mock_client_instance
+        mock_discover.return_value = {"streams": []}
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        mock_client_cls.assert_called_once_with(
+            config_path="/tmp/config.json",
+            config=mock_args.config,
+            dev_mode=False,
+        )
+
+    @patch('tap_shopify.ShopifyClient')
+    @patch('tap_shopify.discover')
+    @patch('singer.utils.parse_args')
+    def test_main_stores_client_in_context(self, mock_parse_args, mock_discover, mock_client_cls):
+        """main() should store the ShopifyClient instance in Context.client."""
+        from tap_shopify import main
+
+        mock_args = MagicMock()
+        mock_args.config = {
+            "shop": "test-shop",
+            "client_id": "cid",
+            "client_secret": "csecret",
+            "access_token": "tok",
+            "token_expires_at": _iso_future(7200),
+            "start_date": "2025-01-01T00:00:00Z",
+        }
+        mock_args.state = {}
+        mock_args.dev = False
+        mock_args.discover = True
+        mock_args.config_path = "/tmp/config.json"
+        mock_args.catalog = None
+        mock_parse_args.return_value = mock_args
+
+        mock_client_instance = MagicMock()
+        mock_client_instance.access_token = "tok"
+        mock_client_cls.return_value = mock_client_instance
+        mock_discover.return_value = {"streams": []}
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        self.assertEqual(Context.client, mock_client_instance)
+
+    @patch('tap_shopify.discover')
+    @patch('singer.utils.parse_args')
+    def test_main_no_client_when_no_access_token(self, mock_parse_args, mock_discover):
+        """main() should NOT create ShopifyClient when access_token is not in config."""
+        from tap_shopify import main
+
+        mock_args = MagicMock()
+        mock_args.config = {
+            "shop": "test-shop",
+            "api_key": "legacy_key",
+            "start_date": "2025-01-01T00:00:00Z",
+        }
+        mock_args.state = {}
+        mock_args.dev = False
+        mock_args.discover = True
+        mock_args.config_path = "/tmp/config.json"
+        mock_args.catalog = None
+        mock_parse_args.return_value = mock_args
+
+        mock_discover.return_value = {"streams": []}
+
+        original_client = Context.client
+        Context.client = None
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        self.assertIsNone(Context.client)
+        Context.client = original_client
+
+    @patch('tap_shopify.ShopifyClient')
+    @patch('tap_shopify.discover')
+    @patch('singer.utils.parse_args')
+    def test_main_updates_config_access_token(self, mock_parse_args, mock_discover, mock_client_cls):
+        """main() should update Context.config['access_token'] from client.access_token."""
+        from tap_shopify import main
+
+        mock_args = MagicMock()
+        mock_args.config = {
+            "shop": "test-shop",
+            "client_id": "cid",
+            "client_secret": "csecret",
+            "access_token": "old_tok",
+            "token_expires_at": _iso_future(7200),
+            "start_date": "2025-01-01T00:00:00Z",
+        }
+        mock_args.state = {}
+        mock_args.dev = False
+        mock_args.discover = True
+        mock_args.config_path = "/tmp/config.json"
+        mock_args.catalog = None
+        mock_parse_args.return_value = mock_args
+
+        mock_client_instance = MagicMock()
+        mock_client_instance.access_token = "refreshed_tok"
+        mock_client_cls.return_value = mock_client_instance
+        mock_discover.return_value = {"streams": []}
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        self.assertEqual(Context.config.get('access_token'), "refreshed_tok")
+
+
+class TestBackoffOnRefresh(unittest.TestCase):
+    """Tests for backoff/retry on token refresh failures."""
+
+    @patch('tap_shopify.client.requests.post')
+    def test_refresh_retries_on_connection_error(self, mock_post):
+        """_refresh_access_token should retry on RequestException."""
+        config = {
+            "shop": "test-shop",
+            "client_id": "cid",
+            "client_secret": "csecret",
+        }
+        tmp = tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False)
+        json.dump(config, tmp)
+        tmp.close()
+
+        try:
+            client = object.__new__(ShopifyClient)
+            client.config = config
+            client.config_path = tmp.name
+            client.dev_mode = False
+
+            # Fail twice then succeed
+            mock_post.side_effect = [
+                requests.exceptions.ConnectionError("Connection refused"),
+                requests.exceptions.ConnectionError("Connection refused"),
+                MagicMock(
+                    status_code=200,
+                    json=MagicMock(return_value={
+                        "access_token": "recovered_token",
+                        "expires_in": 86400,
+                    }),
+                ),
+            ]
+            client._refresh_access_token()
+            self.assertEqual(client.access_token, "recovered_token")
+            self.assertEqual(mock_post.call_count, 3)
+        finally:
+            os.unlink(tmp.name)
+
+    @patch('tap_shopify.client.requests.post')
+    def test_refresh_gives_up_after_max_retries(self, mock_post):
+        """_refresh_access_token should give up after max retries."""
+        config = {
+            "shop": "test-shop",
+            "client_id": "cid",
+            "client_secret": "csecret",
+        }
+        tmp = tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False)
+        json.dump(config, tmp)
+        tmp.close()
+
+        try:
+            client = object.__new__(ShopifyClient)
+            client.config = config
+            client.config_path = tmp.name
+            client.dev_mode = False
+
+            mock_post.side_effect = requests.exceptions.ConnectionError("Connection refused")
+
+            with self.assertRaises(requests.exceptions.ConnectionError):
+                client._refresh_access_token()
+
+            # backoff max_tries=3
+            self.assertEqual(mock_post.call_count, 3)
+        finally:
+            os.unlink(tmp.name)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unittests/test_client.py
+++ b/tests/unittests/test_client.py
@@ -1,10 +1,9 @@
 import json
 import os
-import time
 import datetime
 import tempfile
 import unittest
-from unittest.mock import patch, MagicMock, mock_open, call
+from unittest.mock import patch, MagicMock
 
 import requests
 
@@ -15,7 +14,7 @@ from tap_shopify.client import (
     SHOPIFY_API_VERSION,
 )
 from tap_shopify.context import Context
-
+from tap_shopify.exceptions import ShopifyError
 
 def _iso_future(seconds=7200):
     """Helper to generate an ISO timestamp in the future."""
@@ -313,7 +312,7 @@ class TestRefreshAccessToken(unittest.TestCase):
                 status_code=401,
                 text="Unauthorized",
             )
-            with self.assertRaises(Exception) as ctx:
+            with self.assertRaises(ShopifyError) as ctx:
                 client._refresh_access_token()
             self.assertIn("Failed to obtain access token", str(ctx.exception))
         finally:

--- a/tests/unittests/test_token_check_in_discover.py
+++ b/tests/unittests/test_token_check_in_discover.py
@@ -11,6 +11,7 @@ class Args():
         self.catalog = False
         self.config = {'api_key': 'test', 'shop': 'shop'}
         self.state = False
+        self.dev = False
 
 def resource_not_found_raiser():
     raise pyactiveresource.connection.ResourceNotFound


### PR DESCRIPTION
# Description of change
Adds support for a client-credentials–style authentication flow by introducing a ShopifyClient that can fetch/refresh an access token, and wiring token refresh into GraphQL error handling (401) while keeping legacy api_key support.

Changes:

- Introduces ShopifyClient for token acquisition/persistence and session reinitialization.
- Adds ShopifyUnauthorizedError + a 401 backoff handler that refreshes the token and retries.
- Updates tests and tap-tester credentials wiring to use client_id/client_secret, plus a small CI env tweak.

JIRA - SAC-30422

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
