### PR TITLE
Filter GraphQL field pruning to top-level record selection sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 3.11.0
+  * Filter GraphQL field pruning to top-level record selection sets [#250](https://github.com/singer-io/tap-shopify/pull/250)
+
 ### 3.10.0
   * Add support of client_cred grant type auth [#249](https://github.com/singer-io/tap-shopify/pull/249)
   * Fix current bookmark value for no data time window [#251](https://github.com/singer-io/tap-shopify/pull/251)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages
 
 setup(
     name="tap-shopify",
-    version="3.10.0",
+    version="3.11.0",
     description="Singer.io tap for extracting Shopify data",
     author="Stitch",
     url="http://github.com/singer-io/tap-shopify",
@@ -14,7 +14,7 @@ setup(
     install_requires=[
         # Important: review the monkey-patched method in the GraphQL client when upgrading this dependency.
         "ShopifyAPI==12.7.0",
-        "singer-python==6.1.1",
+        "singer-python==6.8.0",
         "graphql-core==3.2.6",
         'requests==2.32.4',
     ],

--- a/setup.py
+++ b/setup.py
@@ -16,13 +16,13 @@ setup(
         "ShopifyAPI==12.7.0",
         "singer-python==6.8.0",
         "graphql-core==3.2.6",
-        'requests==2.32.4',
+        'requests==2.34.2',
     ],
     extras_require={
         'dev': [
             'pylint==3.3.6',
             'ipdb',
-            'requests==2.32.4',
+            'requests==2.34.2',
             'nose',
         ]
     },

--- a/tap_shopify/streams/base.py
+++ b/tap_shopify/streams/base.py
@@ -235,15 +235,15 @@ class Stream():
 
         class FieldRemover(Visitor):
             def enter_selection_set(self, node, _key, _parent, _path, _ancestors):
-                # Only remove unselected fields at the top-level stream node
-                # (stream_name → edges → node → [top-level fields]).
+                # Only prune fields at the top-level record node (stream → edges → node).
+                # At that point _ancestors has exactly 2 FieldNodes; 'node' is _parent, not an ancestor.
                 field_ancestor_names = [
                     a.name.value
                     for a in _ancestors
                     if isinstance(a, FieldNode)
                 ]
 
-                at_top_level_node = len(field_ancestor_names) == 3
+                at_top_level_node = len(field_ancestor_names) == 2
 
                 new_selections = []
                 for selection in node.selections:

--- a/tap_shopify/streams/base.py
+++ b/tap_shopify/streams/base.py
@@ -235,10 +235,20 @@ class Stream():
 
         class FieldRemover(Visitor):
             def enter_selection_set(self, node, _key, _parent, _path, _ancestors):
+                # Only remove unselected fields at the top-level stream node
+                # (stream_name → edges → node → [top-level fields]).
+                field_ancestor_names = [
+                    a.name.value
+                    for a in _ancestors
+                    if isinstance(a, FieldNode)
+                ]
+
+                at_top_level_node = len(field_ancestor_names) == 3
+
                 new_selections = []
                 for selection in node.selections:
                     if isinstance(selection, FieldNode):
-                        if selection.name.value in fields_to_remove:
+                        if at_top_level_node and selection.name.value in fields_to_remove:
                             continue
                         # Check field arguments for variable usage
                         for arg in selection.arguments or []:

--- a/tap_shopify/streams/base.py
+++ b/tap_shopify/streams/base.py
@@ -236,7 +236,8 @@ class Stream():
         class FieldRemover(Visitor):
             def enter_selection_set(self, node, _key, _parent, _path, _ancestors):
                 # Only prune fields at the top-level record node (stream → edges → node).
-                # At that point _ancestors has exactly 2 FieldNodes; 'node' is _parent, not an ancestor.
+                # At that point _ancestors has exactly 2 FieldNodes; 'node' is _parent,
+                # not an ancestor.
                 field_ancestor_names = [
                     a.name.value
                     for a in _ancestors

--- a/tap_shopify/streams/base.py
+++ b/tap_shopify/streams/base.py
@@ -150,6 +150,16 @@ class Stream():
     data_key = None
     results_per_page = None
 
+    def _get_record_node_path(self):
+        """
+        Returns the exact tuple of FieldNode names leading from the query root
+        to the selection set that holds the stream's top-level record fields.
+
+        The default covers the standard ``{ stream { edges { node { FIELDS } } } }``
+        shape; subclasses whose records sit at a different depth must override.
+        """
+        return (self.data_key, "edges", "node")
+
     def __init__(self):
         self.results_per_page = Context.get_results_per_page(RESULTS_PER_PAGE)
         self.date_window_size = float(Context.config.get("date_window_size") or
@@ -232,26 +242,37 @@ class Stream():
     def remove_fields_from_query(self, fields_to_remove: list) -> str:
         ast = parse(self.get_query())
         used_variable_names = set()
+        # O(1) membership checks.
+        fields_to_remove_set = set(fields_to_remove)
+        # Exact full path from the query root to the record-level selection set.
+        # Exact matching (not suffix) avoids false positives when a nested
+        # connection (e.g. lineItems.edges.node) ends with the same field names.
+        record_path = self._get_record_node_path()
 
         class FieldRemover(Visitor):
-            def enter_selection_set(self, node, _key, _parent, _path, _ancestors):
-                # Only prune fields at the top-level record node (stream → edges → node).
-                # At that point _ancestors has exactly 2 FieldNodes; 'node' is _parent,
-                # not an ancestor.
-                field_ancestor_names = [
-                    a.name.value
-                    for a in _ancestors
-                    if isinstance(a, FieldNode)
-                ]
+            def __init__(self):
+                super().__init__()
+                # Incremental stack of FieldNode names maintained via
+                # enter_field / leave_field — O(1) push/pop per visit.
+                self._field_stack = []
 
-                at_top_level_node = len(field_ancestor_names) == 2
+            def enter_field(self, node, *_):
+                self._field_stack.append(node.name.value)
+
+            def leave_field(self, node, *_):
+                self._field_stack.pop()
+
+            def enter_selection_set(self, node, *_):
+                # Exact match against the full path: only the one selection set
+                # that corresponds to the stream's record node is pruned.
+                at_record_node = tuple(self._field_stack) == record_path
 
                 new_selections = []
                 for selection in node.selections:
                     if isinstance(selection, FieldNode):
-                        if at_top_level_node and selection.name.value in fields_to_remove:
+                        if at_record_node and selection.name.value in fields_to_remove_set:
                             continue
-                        # Check field arguments for variable usage
+                        # Track variable names used in field arguments.
                         for arg in selection.arguments or []:
                             if hasattr(arg.value, "name") and isinstance(arg.value.name, NameNode):
                                 used_variable_names.add(arg.value.name.value)

--- a/tap_shopify/streams/base.py
+++ b/tap_shopify/streams/base.py
@@ -259,7 +259,7 @@ class Stream():
             def enter_field(self, node, *_):
                 self._field_stack.append(node.name.value)
 
-            def leave_field(self, node, *_):
+            def leave_field(self, _node, *_):
                 self._field_stack.pop()
 
             def enter_selection_set(self, node, *_):

--- a/tap_shopify/streams/inventory_levels.py
+++ b/tap_shopify/streams/inventory_levels.py
@@ -12,6 +12,11 @@ class InventoryLevels(Stream):
     child_data_key = "inventoryLevels"
     replication_key = "updatedAt"
 
+    def _get_record_node_path(self):
+        # Inventory-level records live at
+        # locations.edges.node.inventoryLevels.edges.node { FIELDS }.
+        return ("locations", "edges", "node", "inventoryLevels", "edges", "node")
+
     def get_next_page_child(self, parent_id, cursor, child_query):
         """
         Gets all child objects efficiently with pagination.

--- a/tap_shopify/streams/metafields.py
+++ b/tap_shopify/streams/metafields.py
@@ -17,6 +17,11 @@ class Metafields(Stream, ABC):
     child_data_key = "metafields"
     replication_key = "updatedAt"
 
+    def _get_record_node_path(self):
+        # Metafield records live at {data_key}.edges.node.metafields.edges.node.
+        # data_key is defined by each concrete subclass.
+        return (self.data_key, "edges", "node", "metafields", "edges", "node")
+
     @abstractmethod
     def get_query(self):
         """Placeholder for get_query method."""

--- a/tap_shopify/streams/order_refunds.py
+++ b/tap_shopify/streams/order_refunds.py
@@ -13,6 +13,11 @@ class OrderRefunds(Stream):
     replication_key = "updatedAt"
     automatic_keys = ["order"]
 
+    def _get_record_node_path(self):
+        # Refund records live at orders.edges.node.refunds { FIELDS },
+        # not at the standard edges.node depth.
+        return ("orders", "edges", "node", "refunds")
+
     # pylint: disable=too-many-locals
     def get_objects(self):
         """

--- a/tap_shopify/streams/order_shipping_lines.py
+++ b/tap_shopify/streams/order_shipping_lines.py
@@ -12,6 +12,11 @@ class OrderShippingLines(Stream):
     child_data_key = "shippingLines"
     replication_key = "updatedAt"
 
+    def _get_record_node_path(self):
+        # Shipping-line records live at
+        # orders.edges.node.shippingLines.edges.node { FIELDS }.
+        return ("orders", "edges", "node", "shippingLines", "edges", "node")
+
     # pylint: disable=too-many-locals
     def get_objects(self):
         """

--- a/tap_shopify/streams/order_shipping_lines.py
+++ b/tap_shopify/streams/order_shipping_lines.py
@@ -32,6 +32,7 @@ class OrderShippingLines(Stream):
         last_updated_at = self.get_bookmark() - timedelta(minutes=1)
         current_bookmark = self.get_bookmark()
         sync_start = utils.now().replace(microsecond=0)
+        query = self.remove_fields_from_query(Context.get_unselected_fields(self.name))
 
         # Process each date window
         while last_updated_at < sync_start:
@@ -43,14 +44,14 @@ class OrderShippingLines(Stream):
                 query_params = self.get_query_params(last_updated_at, query_end, cursor)
 
                 with metrics.http_request_timer(self.name):
-                    data = self.call_api(query_params)
+                    data = self.call_api(query_params, query=query)
 
                 # Process parent objects and their shippinglines
                 edges = data.get("edges", [])
                 for edge in edges:
                     node = edge.get("node", {})
 
-                    for shipping_line in self.paginate_shipping_lines(node):
+                    for shipping_line in self.paginate_shipping_lines(node, query):
                         shipping_line["orderId"] = node["id"].split("/")[-1]
                         shipping_line["updatedAt"] = node["updatedAt"]
 
@@ -71,12 +72,13 @@ class OrderShippingLines(Stream):
             max_bookmark_value = min(sync_start, current_bookmark)
             self.update_bookmark(utils.strftime(max_bookmark_value))
 
-    def paginate_shipping_lines(self, data):
+    def paginate_shipping_lines(self, data, query):
         """
         Transforms the shippingLines data by handling pagination.
 
         Args:
             data (dict): Order data.
+            query (str): Pruned GraphQL query string.
 
         Returns:
             list: List of shippingLines.
@@ -98,7 +100,7 @@ class OrderShippingLines(Stream):
             }
 
             # Fetch the next page of data
-            response = self.call_api(params)
+            response = self.call_api(params, query=query)
             node = response.get("edges", [])[0].get("node", {})
             shipping_lines_data = node.get("shippingLines")
             for item in shipping_lines_data["edges"]:

--- a/tap_shopify/streams/transactions.py
+++ b/tap_shopify/streams/transactions.py
@@ -12,6 +12,11 @@ class Transactions(Stream):
     child_data_key = "transactions"
     replication_key = "createdAt"
 
+    def _get_record_node_path(self):
+        # Transaction records live at orders.edges.node.transactions { FIELDS },
+        # not at the standard edges.node depth.
+        return ("orders", "edges", "node", "transactions")
+
     # pylint: disable=W0221
     def get_query_params(self, updated_at_min, updated_at_max, cursor=None):
         """

--- a/tests/unittests/test_schema_validation.py
+++ b/tests/unittests/test_schema_validation.py
@@ -4,6 +4,8 @@ import json
 from graphql import parse, FieldNode, SelectionSetNode
 from pathlib import Path
 from tap_shopify.streams.orders import Orders
+from tap_shopify.streams.transactions import Transactions
+from tap_shopify.streams.inventory_levels import InventoryLevels
 from tap_shopify.context import Context
 from tap_shopify.streams.base import Stream
 from textwrap import dedent
@@ -101,6 +103,8 @@ class TestGraphQLSchemaMatch(unittest.TestCase):
 
     def setUp(self):
         class TestClass(Stream):
+            data_key = "products"
+
             def get_query(self):
                 return dedent("""
                     query GetProducts($first: Int!, $after: String, $query: String) {
@@ -242,3 +246,212 @@ class TestGraphQLSchemaMatch(unittest.TestCase):
             ''.join(result.split()),
             ''.join(expected_query.split())
         )
+
+    def test_remove_fields_preserves_nested_same_name_fields(self):
+        """Pruning a top-level field must not remove a same-named field that
+        appears inside a nested connection (e.g. lineItems.edges.node).
+
+        This is the regression guard for the original customAttributes bug:
+        the top-level ``customAttributes`` field on the order record and the
+        ``customAttributes`` field inside ``lineItems.edges.node`` share a
+        name.  If only the order-level one is unselected it must be removed
+        from ``orders.edges.node`` but left intact inside lineItems.
+        """
+        class OrderLikeStream(Stream):
+            data_key = "orders"
+
+            def get_query(self):
+                return dedent("""
+                    query GetOrders($first: Int!) {
+                        orders(first: $first) {
+                            edges {
+                                node {
+                                    id
+                                    customAttributes {
+                                        key
+                                        value
+                                    }
+                                    lineItems {
+                                        edges {
+                                            node {
+                                                id
+                                                customAttributes {
+                                                    key
+                                                    value
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                """)
+
+        stream = OrderLikeStream()
+        result = stream.remove_fields_from_query(["customAttributes"])
+
+        # Top-level customAttributes should be gone; lineItems and its nested
+        # customAttributes should remain intact.
+        parsed = parse(result)
+
+        def get_selection_names(selection_set):
+            return {s.name.value for s in selection_set.selections if isinstance(s, FieldNode)}
+
+        # Navigate: orders → edges → node
+        orders_node = parsed.definitions[0].selection_set.selections[0]
+        edges_node = orders_node.selection_set.selections[0]
+        node_fields = edges_node.selection_set.selections[0]
+        top_level_names = get_selection_names(node_fields.selection_set)
+
+        self.assertNotIn(
+            "customAttributes", top_level_names,
+            "Top-level customAttributes should be pruned from orders.edges.node"
+        )
+        self.assertIn(
+            "lineItems", top_level_names,
+            "lineItems should still be present after pruning"
+        )
+
+        # Navigate into lineItems → edges → node
+        line_items_field = next(
+            s for s in node_fields.selection_set.selections
+            if isinstance(s, FieldNode) and s.name.value == "lineItems"
+        )
+        line_item_edges = line_items_field.selection_set.selections[0]
+        line_item_node = line_item_edges.selection_set.selections[0]
+        line_item_names = get_selection_names(line_item_node.selection_set)
+
+        self.assertIn(
+            "customAttributes", line_item_names,
+            "customAttributes inside lineItems.edges.node must NOT be pruned"
+        )
+
+
+class TestRemoveFieldsTransactions(unittest.TestCase):
+    """remove_fields_from_query correctly prunes fields from the
+    ``transactions { }`` direct-list pattern used by the Transactions stream
+    (orders.edges.node.transactions { FIELDS }, no nested edges/node wrapper).
+    """
+
+    def setUp(self):
+        self.stream = Transactions()
+
+    def _parse_transaction_fields(self, query_str):
+        """Return the set of field names directly inside ``transactions { }``."""
+        parsed = parse(query_str)
+        op = parsed.definitions[0]
+        # orders → edges → node → transactions
+        orders = op.selection_set.selections[0]          # orders
+        edges = orders.selection_set.selections[0]       # edges
+        node = edges.selection_set.selections[0]         # node
+        transactions = next(
+            s for s in node.selection_set.selections
+            if isinstance(s, FieldNode) and s.name.value == "transactions"
+        )
+        return {
+            s.name.value
+            for s in transactions.selection_set.selections
+            if isinstance(s, FieldNode)
+        }
+
+    def test_unselected_fields_pruned_from_transactions(self):
+        """Fields that are unselected should be removed from transactions { }."""
+        result = self.stream.remove_fields_from_query(["gateway", "errorCode"])
+        remaining = self._parse_transaction_fields(result)
+
+        self.assertNotIn("gateway", remaining)
+        self.assertNotIn("errorCode", remaining)
+
+    def test_selected_fields_kept_in_transactions(self):
+        """Fields that ARE selected must remain in transactions { }."""
+        result = self.stream.remove_fields_from_query(["gateway"])
+        remaining = self._parse_transaction_fields(result)
+
+        self.assertIn("id", remaining)
+        self.assertIn("status", remaining)
+        self.assertIn("createdAt", remaining)
+
+    def test_empty_fields_to_remove_leaves_query_intact(self):
+        """Passing an empty list must not alter the transactions fields."""
+        original_fields = self._parse_transaction_fields(self.stream.get_query())
+        result = self.stream.remove_fields_from_query([])
+        pruned_fields = self._parse_transaction_fields(result)
+
+        self.assertEqual(original_fields, pruned_fields)
+
+
+class TestRemoveFieldsInventoryLevels(unittest.TestCase):
+    """remove_fields_from_query correctly targets the inner
+    ``inventoryLevels.edges.node { FIELDS }`` selection set and does NOT
+    prune from the outer ``locations.edges.node`` selection set.
+    """
+
+    def setUp(self):
+        self.stream = InventoryLevels()
+
+    def _parse_outer_location_fields(self, query_str):
+        """Return field names directly inside ``locations.edges.node { }``."""
+        parsed = parse(query_str)
+        op = parsed.definitions[0]
+        locations = op.selection_set.selections[0]        # locations
+        edges = locations.selection_set.selections[0]     # edges
+        node = edges.selection_set.selections[0]          # outer node
+        return {
+            s.name.value
+            for s in node.selection_set.selections
+            if isinstance(s, FieldNode)
+        }
+
+    def _parse_inner_inventory_level_fields(self, query_str):
+        """Return field names directly inside ``inventoryLevels.edges.node { }``."""
+        parsed = parse(query_str)
+        op = parsed.definitions[0]
+        locations = op.selection_set.selections[0]
+        edges = locations.selection_set.selections[0]
+        outer_node = edges.selection_set.selections[0]
+        inventory_levels = next(
+            s for s in outer_node.selection_set.selections
+            if isinstance(s, FieldNode) and s.name.value == "inventoryLevels"
+        )
+        inner_edges = next(
+            s for s in inventory_levels.selection_set.selections
+            if isinstance(s, FieldNode) and s.name.value == "edges"
+        )
+        inner_node = inner_edges.selection_set.selections[0]
+        return {
+            s.name.value
+            for s in inner_node.selection_set.selections
+            if isinstance(s, FieldNode)
+        }
+
+    def test_unselected_fields_pruned_from_inner_node(self):
+        """Unselected inventory-level fields are removed from the inner node."""
+        result = self.stream.remove_fields_from_query(["canDeactivate", "deactivationAlert"])
+        inner_fields = self._parse_inner_inventory_level_fields(result)
+
+        self.assertNotIn("canDeactivate", inner_fields)
+        self.assertNotIn("deactivationAlert", inner_fields)
+
+    def test_outer_location_node_is_not_pruned(self):
+        """The outer locations.edges.node must never be touched by pruning."""
+        original_outer = self._parse_outer_location_fields(self.stream.get_query())
+        result = self.stream.remove_fields_from_query(["canDeactivate", "id", "updatedAt"])
+        pruned_outer = self._parse_outer_location_fields(result)
+
+        # The outer node must be unchanged regardless of what fields_to_remove contains.
+        self.assertEqual(
+            original_outer, pruned_outer,
+            "Pruning inventory-level schema fields must not affect the outer "
+            "locations.edges.node selection set"
+        )
+
+    def test_selected_fields_kept_in_inner_node(self):
+        """Fields that ARE selected must remain in the inner inventory-level node."""
+        result = self.stream.remove_fields_from_query(["canDeactivate"])
+        inner_fields = self._parse_inner_inventory_level_fields(result)
+
+        self.assertIn("id", inner_fields)
+        self.assertIn("updatedAt", inner_fields)
+        self.assertIn("item", inner_fields)
+


### PR DESCRIPTION
## Description

Improves the GraphQL AST field-pruning logic (`remove_fields_from_query`) to scope field removal precisely to a stream's **top-level record selection set**, preventing unintended removal of identically-named fields in nested connections.

### Background

When a field is deselected in the catalog, `remove_fields_from_query` prunes it from the outgoing GraphQL query. However, some field names (e.g. `customAttributes`) appear at multiple depths in the same query — both on the top-level record and inside nested connections like `lineItems.edges.node`. Pruning should only target the top-level record fields, leaving nested occurrences intact.

Additionally, not all streams follow the standard `edges → node` record shape — streams like `transactions`, `inventory_levels`, and `order_shipping_lines` have deeper or differently structured paths that require per-stream awareness.

### Changes

- Added `_get_record_node_path()` to the base `Stream` class, returning the **exact path tuple** from the query root to the stream's record-level selection set. Default covers the standard `(data_key, "edges", "node")` shape.
- `FieldRemover` now tracks traversal depth via an `enter_field`/`leave_field` stack and only prunes when the current path exactly matches the stream's record path.
- Streams with non-standard record shapes override `_get_record_node_path()`:

| Stream | Record path |
|---|---|
| `InventoryLevels` | `locations → edges → node → inventoryLevels → edges → node` |
| `Metafields` | `{data_key} → edges → node → metafields → edges → node` |
| `OrderRefunds` | `orders → edges → node → refunds` |
| `OrderShippingLines` | `orders → edges → node → shippingLines → edges → node` |
| `Transactions` | `orders → edges → node → transactions` |

- Wired `remove_fields_from_query` into `OrderShippingLines.get_objects()` and `paginate_shipping_lines()`, ensuring the pruned query is passed to all `call_api` invocations.
- Bumped singer-python from `6.1.1` to `6.8.0`.

### Testing

- `test_remove_fields_preserves_nested_same_name_fields` — validates that pruning `customAttributes` at the order level leaves `customAttributes` inside `lineItems.edges.node` untouched
- `TestRemoveFieldsTransactions` — validates correct pruning for the direct-list `transactions { }` pattern
- `TestRemoveFieldsInventoryLevels` — validates that only the inner `inventoryLevels.edges.node` is pruned and the outer `locations.edges.node` is unaffected

### QA Steps
- [x] Automated tests passing
- [x] Manual QA: deselect a field that also appears in a nested connection (e.g. deselect `customAttributes` on `orders`) and confirm replication outputs correct data

# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
