### PR TITLE
SAC-30546: Fix current bookmark value for no data time window

### DIFF
--- a/tap_shopify/streams/orders.py
+++ b/tap_shopify/streams/orders.py
@@ -1271,7 +1271,6 @@ class Orders(Stream):
             else:
                 LOGGER.info("No data returned for the date range: %s to %s",
                                last_updated_at, query_end)
-                current_bookmark = max(current_bookmark, query_end)
 
             self.clear_bulk_operation_state()
             last_updated_at = query_end

--- a/tests/test_interrupted_sync.py
+++ b/tests/test_interrupted_sync.py
@@ -38,9 +38,7 @@ class InterruptedSyncTest(BaseTapTest):
 
         expected_streams = {'customers',
                             'collections',
-                            #'orders',
-                            # TODO: SAC-30638 - add orders stream back to the test after
-                            # fixing the issue with orders stream bookmark value
+                            'orders',
                             'events',
                             'products',
                             'transactions'}
@@ -92,9 +90,7 @@ class InterruptedSyncTest(BaseTapTest):
         base_state = {'bookmarks':
                      {'currently_sync_stream': currently_syncing_stream,
                       'customers': first_sync_state.get('bookmarks').get('customers'),
-                      #'orders': first_sync_state.get('bookmarks').get('orders'),
-                      # TODO: SAC-30638 - add orders stream back to the test after 
-                      # fixing the issue with orders stream bookmark value
+                      'orders': first_sync_state.get('bookmarks').get('orders'),
                       'collections': first_sync_state.get('bookmarks').get('collections'),
                       'events': first_sync_state.get('bookmarks').get('events'),
                       'products': first_sync_state.get('bookmarks').get('products'),

--- a/tests/test_interrupted_sync.py
+++ b/tests/test_interrupted_sync.py
@@ -38,7 +38,7 @@ class InterruptedSyncTest(BaseTapTest):
 
         expected_streams = {'customers',
                             'collections',
-                            'orders',
+                            'events',
                             'products',
                             'transactions'}
 
@@ -89,7 +89,8 @@ class InterruptedSyncTest(BaseTapTest):
         base_state = {'bookmarks':
                      {'currently_sync_stream': currently_syncing_stream,
                       'customers': first_sync_state.get('bookmarks').get('customers'),
-                      'orders': first_sync_state.get('bookmarks').get('orders'),
+                      'collections': first_sync_state.get('bookmarks').get('collections'),
+                      'events': first_sync_state.get('bookmarks').get('events'),
                       'products': first_sync_state.get('bookmarks').get('products'),
                       'transactions': first_sync_state.get('bookmarks').get('transactions')
                       }}

--- a/tests/test_interrupted_sync.py
+++ b/tests/test_interrupted_sync.py
@@ -38,6 +38,9 @@ class InterruptedSyncTest(BaseTapTest):
 
         expected_streams = {'customers',
                             'collections',
+                            #'orders',
+                            # TODO: SAC-30638 - add orders stream back to the test after
+                            # fixing the issue with orders stream bookmark value
                             'events',
                             'products',
                             'transactions'}
@@ -89,6 +92,9 @@ class InterruptedSyncTest(BaseTapTest):
         base_state = {'bookmarks':
                      {'currently_sync_stream': currently_syncing_stream,
                       'customers': first_sync_state.get('bookmarks').get('customers'),
+                      #'orders': first_sync_state.get('bookmarks').get('orders'),
+                      # TODO: SAC-30638 - add orders stream back to the test after 
+                      # fixing the issue with orders stream bookmark value
                       'collections': first_sync_state.get('bookmarks').get('collections'),
                       'events': first_sync_state.get('bookmarks').get('events'),
                       'products': first_sync_state.get('bookmarks').get('products'),

--- a/tests/test_interrupted_sync.py
+++ b/tests/test_interrupted_sync.py
@@ -39,7 +39,6 @@ class InterruptedSyncTest(BaseTapTest):
         expected_streams = {'customers',
                             'collections',
                             'orders',
-                            'events',
                             'products',
                             'transactions'}
 
@@ -92,7 +91,6 @@ class InterruptedSyncTest(BaseTapTest):
                       'customers': first_sync_state.get('bookmarks').get('customers'),
                       'orders': first_sync_state.get('bookmarks').get('orders'),
                       'collections': first_sync_state.get('bookmarks').get('collections'),
-                      'events': first_sync_state.get('bookmarks').get('events'),
                       'products': first_sync_state.get('bookmarks').get('products'),
                       'transactions': first_sync_state.get('bookmarks').get('transactions')
                       }}


### PR DESCRIPTION
# Description of change
JIRA: https://qlik-dev.atlassian.net/browse/SAC-30546
Bug: https://qlik-dev.atlassian.net/browse/SAC-30638

**Changes**

- added **collections** to the base_state
- removed the current_bookmark line to make sure it uses the last updatedAt when they have records. Currently the value is being to set now which causes the test to fail [[SAC-30638](https://qlik-dev.atlassian.net/browse/SAC-30638)]

# QA steps
 - [x] automated tests passing
 - [x] manual qa steps passing (list below)
 