### PR TITLE
Fix: Add HTTP error handling for fetch_app_scopes GraphQL query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 3.12.1
+  * Add HTTP error handling (with timeout, 401 mapping to `ShopifyUnauthorizedError`, and request-id/reason context) for `fetch_app_scopes()` GraphQL query [#254](https://github.com/singer-io/tap-shopify/pull/254)
+
 ### 3.12.0
   * Re-stringify JSON values in transform_object to prevent SQL error 22P02 for QTC. [#253](https://github.com/singer-io/tap-shopify/pull/253)
   * Fix metafield schema SQL type conflicts.

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages
 
 setup(
     name="tap-shopify",
-    version="3.12.0",
+    version="3.12.1",
     description="Singer.io tap for extracting Shopify data",
     author="Stitch",
     url="http://github.com/singer-io/tap-shopify",

--- a/tap_shopify/__init__.py
+++ b/tap_shopify/__init__.py
@@ -53,14 +53,26 @@ def fetch_app_scopes():
     }
     """
     try:
-        data = json.loads(shopify.GraphQL().execute(query))
+        # pylint: disable=unexpected-keyword-arg
+        # execute() is monkey-patched in base.py (execute_gql) to accept timeout
+        data = json.loads(shopify.GraphQL().execute(query, timeout=get_request_timeout()))
     except urllib.error.HTTPError as http_error:
+        # Extract X-Request-ID from the error response headers
+        request_id = http_error.headers.get("X-Request-ID")
+        error_body = http_error.read().decode("utf-8") if http_error.fp else None
+        error_message = (
+            f"{http_error.reason} - {error_body}"
+            if error_body
+            else http_error.reason
+        )
         if http_error.code == 401:
             raise ShopifyUnauthorizedError(http_error,
-                f"Unauthorized access - token may have expired with status {http_error.code}."
+                f"Unauthorized access - token may have expired with status {http_error.code} "
+                f"and X-Request-ID '{request_id or 'N/A'}', Reason: {error_message}."
             ) from http_error
         raise ShopifyError(http_error,
-            f"GraphQL request failed while fetching app scopes with status {http_error.code}."
+            f"GraphQL request failed while fetching app scopes with status {http_error.code} "
+            f"and X-Request-ID '{request_id or 'N/A'}', Reason: {error_message}."
         ) from http_error
     return {s["handle"] for s in data["data"]["currentAppInstallation"]["accessScopes"]}
 

--- a/tap_shopify/__init__.py
+++ b/tap_shopify/__init__.py
@@ -5,6 +5,7 @@ import json
 import time
 import math
 import copy
+import urllib.error
 
 import pyactiveresource
 import shopify
@@ -40,6 +41,7 @@ def initialize_shopify_client():
         raise ShopifyUnauthorizedError(exc, "Invalid access token") from exc
 
 # Add helper
+@shopify_error_handling
 def fetch_app_scopes():
     query = """
     query {
@@ -50,7 +52,16 @@ def fetch_app_scopes():
       }
     }
     """
-    data = json.loads(shopify.GraphQL().execute(query))
+    try:
+        data = json.loads(shopify.GraphQL().execute(query))
+    except urllib.error.HTTPError as http_error:
+        if http_error.code == 401:
+            raise ShopifyUnauthorizedError(http_error,
+                f"Unauthorized access - token may have expired with status {http_error.code}."
+            ) from http_error
+        raise ShopifyError(http_error,
+            f"GraphQL request failed while fetching app scopes with status {http_error.code}."
+        ) from http_error
     return {s["handle"] for s in data["data"]["currentAppInstallation"]["accessScopes"]}
 
 def has_read_users_access():

--- a/tests/unittests/test_fetch_app_scopes.py
+++ b/tests/unittests/test_fetch_app_scopes.py
@@ -1,0 +1,75 @@
+import json
+import unittest
+import urllib.error
+from unittest.mock import patch, MagicMock
+
+import tap_shopify
+from tap_shopify.context import Context
+from tap_shopify.exceptions import ShopifyError, ShopifyUnauthorizedError
+
+
+class TestFetchAppScopes(unittest.TestCase):
+    """Tests for tap_shopify.fetch_app_scopes()."""
+
+    def setUp(self):
+        Context.client = None
+
+    @patch('time.sleep', return_value=None)
+    @patch('tap_shopify.get_request_timeout', return_value=300)
+    @patch('shopify.GraphQL')
+    def test_success_returns_scopes_and_passes_timeout(self, mock_graphql, mock_get_timeout, mock_sleep):
+        """A successful call should return the set of granted scopes and pass an explicit timeout."""
+        mock_response = {
+            "data": {
+                "currentAppInstallation": {
+                    "accessScopes": [{"handle": "read_products"}, {"handle": "read_users"}]
+                }
+            }
+        }
+        mock_graphql.return_value.execute.return_value = json.dumps(mock_response)
+
+        scopes = tap_shopify.fetch_app_scopes()
+
+        self.assertEqual(scopes, {"read_products", "read_users"})
+        _, kwargs = mock_graphql.return_value.execute.call_args
+        self.assertEqual(kwargs.get('timeout'), 300)
+
+    @patch('time.sleep', return_value=None)
+    @patch('shopify.GraphQL')
+    def test_401_http_error_raises_shopify_unauthorized_error(self, mock_graphql, mock_sleep):
+        """A 401 HTTPError should be mapped to ShopifyUnauthorizedError."""
+        mock_client = MagicMock()
+        mock_client.refresh_token.return_value = False
+        Context.client = mock_client
+
+        http_error = urllib.error.HTTPError(
+            url="https://test-shop.myshopify.com/admin/api/graphql.json",
+            code=401,
+            msg="Unauthorized",
+            hdrs=MagicMock(**{"get.return_value": "req-401"}),
+            fp=None,
+        )
+        mock_graphql.return_value.execute.side_effect = http_error
+
+        with self.assertRaises(ShopifyUnauthorizedError):
+            tap_shopify.fetch_app_scopes()
+
+    @patch('time.sleep', return_value=None)
+    @patch('shopify.GraphQL')
+    def test_non_401_http_error_raises_shopify_error(self, mock_graphql, mock_sleep):
+        """A non-401 HTTPError (e.g. 500) should be mapped to ShopifyError."""
+        http_error = urllib.error.HTTPError(
+            url="https://test-shop.myshopify.com/admin/api/graphql.json",
+            code=500,
+            msg="Internal Server Error",
+            hdrs=MagicMock(**{"get.return_value": "req-500"}),
+            fp=None,
+        )
+        mock_graphql.return_value.execute.side_effect = http_error
+
+        with self.assertRaises(ShopifyError):
+            tap_shopify.fetch_app_scopes()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Description
This PR improves error handling in the `fetch_app_scopes()` function when executing GraphQL queries.

## Changes
- Added proper exception handling for HTTP errors when fetching app scopes via GraphQL
- Added specific handling for 401 Unauthorized errors to raise `ShopifyUnauthorizedError` with a clear message about token expiration
- Added general HTTP error handling to raise `ShopifyError` for other error codes
- Applied `@shopify_error_handling` decorator to the function for consistent error handling
- Bumped version from 3.12.0 to 3.12.1

## Problem Solved
Previously, HTTP errors (especially 401 unauthorized errors) during the GraphQL query execution in `fetch_app_scopes()` were not being properly caught and handled, which could lead to unclear error messages or unhandled exceptions.

## Testing
- Verify that expired or invalid tokens now produce clear `ShopifyUnauthorizedError` messages
- Verify that other HTTP errors are properly caught and reported
 
# Risks
- Less Risk, as it adds retry for 401 unauthorized error.

# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
